### PR TITLE
Sort proposals by expiration date

### DIFF
--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -98,6 +98,7 @@ type alias ActiveProposal =
     , actionType : String
     , metadataUrl : String
     , metadataHash : String
+    , epoch_validity : { start : Int, end : Int }
     , metadata : RemoteData String ProposalMetadata
     }
 
@@ -106,7 +107,7 @@ ogmiosGovProposalsDecoder : Decoder (List ActiveProposal)
 ogmiosGovProposalsDecoder =
     JD.field "result" <|
         JD.list <|
-            JD.map5 ActiveProposal
+            JD.map6 ActiveProposal
                 (JD.map2
                     (\id index ->
                         { transactionId = Bytes.fromHexUnchecked id
@@ -119,6 +120,11 @@ ogmiosGovProposalsDecoder =
                 (JD.at [ "action", "type" ] JD.string)
                 (JD.at [ "metadata", "url" ] JD.string)
                 (JD.at [ "metadata", "hash" ] JD.string)
+                (JD.map2
+                    (\start end -> { start = start, end = end })
+                    (JD.at [ "since", "epoch" ] JD.int)
+                    (JD.at [ "until", "epoch" ] JD.int)
+                )
                 (JD.succeed RemoteData.Loading)
 
 

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -2674,7 +2674,9 @@ viewProposalSelectionStep ctx model =
                                     Dict.size proposalsDict
 
                                 visibleProposals =
-                                    List.take visibleCount allProposals
+                                    -- Sort proposals by expiration date
+                                    List.sortBy (\proposal -> proposal.epoch_validity.end) allProposals
+                                        |> List.take visibleCount
 
                                 hasMore =
                                     totalCount > visibleCount


### PR DESCRIPTION
I initially thought that there might still some expired proposals in the list we receive from Ogmios (via Koios) but it doesn’t seem to be the case. So for now, let’s just sort proposals by expiration date and if we encounter a point where there an expired proposal, we can fix that later.