### PR TITLE
Update wallet UTxOs after tx submission

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
         with:
           src: "./backend"
 
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
         with:
           src: "./backend"
           args: "format --check"

--- a/frontend/src/Page/Signing.elm
+++ b/frontend/src/Page/Signing.elm
@@ -1,4 +1,4 @@
-module Page.Signing exposing (LoadedTxModel, Model(..), Msg(..), UpdateContext, ViewContext, addWalletSignatures, initialModel, recordSubmittedTx, resetSubmission, update, view)
+module Page.Signing exposing (LoadedTxModel, Model(..), Msg(..), UpdateContext, ViewContext, addWalletSignatures, getTxInfo, initialModel, recordSubmittedTx, resetSubmission, update, view)
 
 {-| This module handles the signing process for Cardano transactions, particularly
 focusing on complex scenarios like Native or Plutus script multi-signatures.
@@ -79,6 +79,16 @@ initialModel expectedSigners maybeTx =
 
         Nothing ->
             MissingTx
+
+
+getTxInfo : Model -> Maybe { tx : Transaction, txId : Bytes TransactionId }
+getTxInfo model =
+    case model of
+        LoadedTx loadedTxModel ->
+            Just { tx = loadedTxModel.tx, txId = loadedTxModel.txId }
+
+        _ ->
+            Nothing
 
 
 


### PR DESCRIPTION
This change enable doing a second vote without having to disconnect/reconnect the wallet. Otherwise the known wallet UTxOs would be stale after the first vote, and most likely lead to failed second Tx.