### PR TITLE
Unexpose sub-pages models

### DIFF
--- a/frontend/src/Page/MultisigRegistration.elm
+++ b/frontend/src/Page/MultisigRegistration.elm
@@ -1,4 +1,4 @@
-module Page.MultisigRegistration exposing (LoadedWallet, Model, Msg(..), RegisterTxSummary, UnregisterTxSummary, UpdateContext, ViewContext, initialModel, update, view)
+module Page.MultisigRegistration exposing (LoadedWallet, Model, Msg, RegisterTxSummary, UnregisterTxSummary, UpdateContext, ViewContext, initialModel, update, view)
 
 {-| This module handles the registration and unregistration of multisig DReps (Delegated Representatives)
 in the Cardano governance system.

--- a/frontend/src/Page/Pdf.elm
+++ b/frontend/src/Page/Pdf.elm
@@ -1,4 +1,4 @@
-module Page.Pdf exposing (GovMetadataFile(..), Model, Msg(..), UpdateContext, ViewContext, initialModel, update, view)
+module Page.Pdf exposing (GovMetadataFile, Model, Msg, UpdateContext, ViewContext, initialModel, update, view)
 
 {-| This module handles the conversion of governance metadata JSON-LD files to PDF format.
 It specifically supports CIP-136 vote rationale documents, with potential for extension

--- a/frontend/src/Page/Signing.elm
+++ b/frontend/src/Page/Signing.elm
@@ -1,4 +1,4 @@
-module Page.Signing exposing (LoadedTxModel, Model(..), Msg(..), UpdateContext, ViewContext, addWalletSignatures, getTxInfo, initialModel, recordSubmittedTx, resetSubmission, update, view)
+module Page.Signing exposing (Model, Msg, UpdateContext, ViewContext, addWalletSignatures, getTxInfo, initialModel, recordSubmittedTx, resetSubmission, update, view)
 
 {-| This module handles the signing process for Cardano transactions, particularly
 focusing on complex scenarios like Native or Plutus script multi-signatures.


### PR DESCRIPTION
The general idea is that a page is a full TEA component with its own Model/Update/View so all its internal working should stay internal. Only types and functions used at it’s API frontier should be exposed to outside modules.