### PR TITLE
Auto-generate the PDF and embed it in the JSON rationale

### DIFF
--- a/frontend/review/suppressed/NoDebug.Log.json
+++ b/frontend/review/suppressed/NoDebug.Log.json
@@ -1,8 +1,0 @@
-{
-  "version": 1,
-  "automatically created by": "elm-review suppress",
-  "learn more": "elm-review suppress --help",
-  "suppressions": [
-    { "count": 1, "filePath": "src/Page/Preparation.elm" }
-  ]
-}

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -1541,7 +1541,11 @@ validateRationaleForm step =
             in
             case rationaleValidation of
                 Ok _ ->
-                    Done form (rationaleFromForm form)
+                    let
+                        formWithoutError =
+                            { form | error = Nothing }
+                    in
+                    Done formWithoutError (rationaleFromForm formWithoutError)
 
                 Err err ->
                     Preparing { form | error = Just err }

--- a/frontend/static/index.html
+++ b/frontend/static/index.html
@@ -79,6 +79,23 @@
             // mainApp.ports.onUrlChange.send(location.href);
         });
 
+        // Convert hex string to binary data
+        function hexToArrayBuffer(hexString) {
+            const bytes = new Uint8Array(hexString.length / 2);    
+            for (let i = 0; i < hexString.length; i += 2) {
+                bytes[i / 2] = parseInt(hexString.substring(i, i + 2), 16);
+            }
+            return bytes.buffer;
+        }
+
+        // Autogened PDF conversion from Hex to File
+        mainApp.ports.pdfBytesToFile.subscribe(async function (data) {
+            const file = new File([hexToArrayBuffer(data.fileContentHex)], data.fileName, {
+                type: "application/pdf",
+            });
+            mainApp.ports.gotPdfAsFile.send(file);
+        });
+
         // JSON rationale conversion from String to File
         mainApp.ports.jsonRationaleToFile.subscribe(async function (data) {
             const file = new File([data.fileContent], data.fileName, {


### PR DESCRIPTION
This PR adds the feature enabling auto-generation of the (unsigned) PDF of the rationale, auto-pinning to IPFS, followed by auto-editing of the rationale statement and rationale references.

This feature is enabled when clicking the "Auto-generate PDF ..." checkbox

<img width="606" alt="image" src="https://github.com/user-attachments/assets/088f4d3e-5162-4d8d-9641-c692d53c6b2d" />

Some places might need a little bit of prettifying like the display of the storage config step when validated.

<img width="533" alt="image" src="https://github.com/user-attachments/assets/106c7443-aa5f-4ca9-b04f-3466b03905cd" />

I also added the proposal ID to the json metadata so that the Typst template can pick it up. So now the auto-generated PDF will look like this.

<img width="695" alt="image" src="https://github.com/user-attachments/assets/8f6a9127-cb0f-4767-9d3d-13794e3894f8" />

Note also that the auto-edited rationale contains a markdown link, the text "PDF version" is clickable. But it’s not visible in the markdown pre-visualization, so the markdown view function might also need some little changes.

<img width="1067" alt="image" src="https://github.com/user-attachments/assets/407c50c2-eb7c-4739-a236-8361ebb21696" />
