### PR TITLE
Diversify IPFS offering (add NMKR)

### DIFF
--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -21,6 +21,7 @@ import Natural exposing (Natural)
 import ProposalMetadata exposing (ProposalMetadata)
 import RemoteData exposing (RemoteData)
 import ScriptInfo exposing (ScriptInfo)
+import Task
 
 
 {-| Free Tier Koios API token.
@@ -54,6 +55,7 @@ type alias ApiProvider msg =
     , getCcInfo : NetworkId -> Credential -> (Result Http.Error CcInfo -> msg) -> Cmd msg
     , getPoolLiveStake : NetworkId -> Bytes Pool.Id -> (Result Http.Error PoolInfo -> msg) -> Cmd msg
     , ipfsAddFileCustom : { rpc : String, headers : List ( String, String ), file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
+    , ipfsAddFileNmkr : { userId : String, apiToken : String, file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
     , ipfsAddFile : { file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
     , convertToPdf : String -> (Result Http.Error ElmBytes.Bytes -> msg) -> Cmd msg
     }
@@ -375,6 +377,8 @@ ipfsAnswerDecoder =
             (JD.field "message" JD.string)
             (JD.field "status_code" JD.int)
         , JD.map IpfsError
+            (JD.field "errorMessage" JD.string)
+        , JD.map IpfsError
             (JD.field "detail" JD.string)
         , JD.map (\json -> IpfsError <| JE.encode 2 json)
             (JD.field "detail" JD.value)
@@ -390,6 +394,10 @@ ipfsAnswerDecoder =
             (JD.field "Name" JD.string)
             (JD.field "Hash" JD.string)
             (JD.field "Size" JD.string)
+
+        -- NMKR format
+        , JD.map (\cid -> IpfsAddSuccessful <| IpfsFile "unkown" cid "unknown")
+            JD.string
         ]
 
 
@@ -565,7 +573,46 @@ defaultApiProvider =
                 , tracker = Nothing
                 }
 
-    -- Make a request to an IPFS server at the CF
+    -- Make a request to NMKR IPFS server
+    , ipfsAddFileNmkr =
+        \{ userId, apiToken, file } toMsg ->
+            File.toUrl file
+                |> Task.andThen
+                    (\fileAsBase64Url ->
+                        let
+                            -- Remove the uri prefix for NMKR which doesn’t accept it
+                            prefixSize =
+                                String.length <| "data:" ++ File.mime file ++ ";base64,"
+
+                            fileAsBase64 =
+                                String.dropLeft prefixSize fileAsBase64Url
+                        in
+                        Http.task
+                            { method = "POST"
+                            , url = "/proxy/json"
+                            , headers = []
+                            , body =
+                                Http.jsonBody
+                                    (JE.object
+                                        [ ( "url", JE.string <| "https://studio-api.nmkr.io/v2/UploadToIpfs/" ++ userId )
+                                        , ( "method", JE.string "POST" )
+                                        , ( "headers", JE.object [ ( "Authorization", JE.string ("Bearer " ++ apiToken) ) ] )
+                                        , ( "body"
+                                          , JE.object
+                                                [ ( "mimetype", JE.string <| File.mime file )
+                                                , ( "name", JE.string <| File.name file )
+                                                , ( "fileFromBase64", JE.string fileAsBase64 )
+                                                ]
+                                          )
+                                        ]
+                                    )
+                            , resolver = Http.stringResolver responseToIpfsAnswer
+                            , timeout = Nothing
+                            }
+                    )
+                |> Task.attempt toMsg
+
+    -- Make a request to the pre-configured IPFS RPC via the server
     , ipfsAddFile =
         \{ file } toMsg ->
             Http.request

--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -53,8 +53,8 @@ type alias ApiProvider msg =
     , getDrepInfo : NetworkId -> Credential -> (Result Http.Error DrepInfo -> msg) -> Cmd msg
     , getCcInfo : NetworkId -> Credential -> (Result Http.Error CcInfo -> msg) -> Cmd msg
     , getPoolLiveStake : NetworkId -> Bytes Pool.Id -> (Result Http.Error PoolInfo -> msg) -> Cmd msg
-    , ipfsAdd : { rpc : String, headers : List ( String, String ), file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
-    , ipfsCfAdd : { file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
+    , ipfsAddFileCustom : { rpc : String, headers : List ( String, String ), file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
+    , ipfsAddFile : { file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
     , convertToPdf : String -> (Result Http.Error ElmBytes.Bytes -> msg) -> Cmd msg
     }
 
@@ -553,7 +553,7 @@ defaultApiProvider =
                 }
 
     -- Make a request to an IPFS RPC
-    , ipfsAdd =
+    , ipfsAddFileCustom =
         \{ rpc, headers, file } toMsg ->
             Http.request
                 { method = "POST"
@@ -566,7 +566,7 @@ defaultApiProvider =
                 }
 
     -- Make a request to an IPFS server at the CF
-    , ipfsCfAdd =
+    , ipfsAddFile =
         \{ file } toMsg ->
             Http.request
                 { method = "POST"

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -348,8 +348,7 @@ type StorageConfig
 
 
 type alias Storage =
-    { config : StorageConfig
-    , jsonFile : IpfsFile
+    { jsonFile : IpfsFile
     }
 
 
@@ -1063,16 +1062,16 @@ innerUpdate ctx msg model =
                     ( model, Cmd.none, Nothing )
 
         GotIpfsAnswer (Ok ipfsAnswer) ->
-            case ( model.storageConfigStep, model.rationaleCreationStep, model.permanentStorageStep ) of
+            case ( model.rationaleCreationStep, model.permanentStorageStep ) of
                 -- If we are validating the rationale form, it means the IPFS answer
                 -- is most likely the PDF we got back for PDF auto-gen.
-                ( Done _ _, Validating form rationale, _ ) ->
+                ( Validating form rationale, _ ) ->
                     handlePdfIpfsAnswer ctx model form rationale ipfsAnswer
 
                 -- Otherwise, if we are validating the permanent storage step, it means the IPFS answer
                 -- is most likely for the signed JSON rationale.
-                ( Done _ storageConfig, _, Validating _ _ ) ->
-                    handleRationaleIpfsAnswer model storageConfig ipfsAnswer
+                ( _, Validating _ _ ) ->
+                    handleRationaleIpfsAnswer model ipfsAnswer
 
                 _ ->
                     ( model, Cmd.none, Nothing )
@@ -2280,8 +2279,8 @@ handlePdfIpfsAnswer ctx model form rationale ipfsAnswer =
             ( model, Cmd.none, Nothing )
 
 
-handleRationaleIpfsAnswer : InnerModel -> StorageConfig -> IpfsAnswer -> ( InnerModel, Cmd msg, Maybe MsgToParent )
-handleRationaleIpfsAnswer model storageConfig ipfsAnswer =
+handleRationaleIpfsAnswer : InnerModel -> IpfsAnswer -> ( InnerModel, Cmd msg, Maybe MsgToParent )
+handleRationaleIpfsAnswer model ipfsAnswer =
     case ipfsAnswer of
         IpfsError error ->
             ( { model | permanentStorageStep = Preparing { error = Just error } }
@@ -2290,7 +2289,7 @@ handleRationaleIpfsAnswer model storageConfig ipfsAnswer =
             )
 
         IpfsAddSuccessful file ->
-            ( { model | permanentStorageStep = Done { error = Nothing } { config = storageConfig, jsonFile = file } }
+            ( { model | permanentStorageStep = Done { error = Nothing } { jsonFile = file } }
             , Cmd.none
             , Nothing
             )

--- a/frontend/static/index.html
+++ b/frontend/static/index.html
@@ -44,6 +44,10 @@
                 jsonLdContexts,
                 db,
                 networkId: {{network_id}}, // 0: Preview, 1: Mainnet
+                ipfsPreconfig: {
+                    label: "Pre-configured IPFS (Cardano Foundation)",
+                    description: "Files will be stored using the Cardano Foundation's IPFS gateway.",
+                },
             },
         });
         ElmCardano.init({


### PR DESCRIPTION
This PR adds support for NMKR to be used as the IPFS server, and create also a dedicated (easier) option for Blockfrost.

Remark that NMKR doesn’t allow CORS, so we need to proxy these request to their servers via our server.
Also remark that currently, NMKR IPFS seems to work for text documents (mime type "text/plain") but not for PDF documents (mime type "application/pdf").

A follow up PR should later deal with customization of the pre-configured IPFS server in our python server. This PR already prepares some ground work for that since the label and description texts for the pre-configured IPFS option are now passed as argument in the app flags in the index.html file.