### PR TITLE
Check metadata hash validity

### DIFF
--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -1232,8 +1232,8 @@ showMoreButton hasMore visibleCount totalCount clickMsg =
 
 {-| Card for an individual proposal
 -}
-proposalCard : { id : String, title : String, abstract : String, actionType : String, actionId : String, linkUrl : String, linkHex : String, index : Int } -> msg -> Html msg -> Html msg
-proposalCard { title, abstract, actionType, linkUrl, linkHex, index } selectMsg actionIcon =
+proposalCard : { id : String, hashIsValid : Bool, title : String, abstract : String, actionType : String, actionId : String, linkUrl : String, linkHex : String, index : Int } -> msg -> Html msg -> Html msg
+proposalCard { title, hashIsValid, abstract, actionType, linkUrl, linkHex, index } selectMsg actionIcon =
     div
         [ HA.style "border" "1px solid #E2E8F0"
         , HA.style "border-radius" "0.75rem"
@@ -1263,7 +1263,12 @@ proposalCard { title, abstract, actionType, linkUrl, linkHex, index } selectMsg 
                 , HA.style "word-wrap" "break-word"
                 , HA.style "flex" "1"
                 ]
-                [ text title ]
+                (if hashIsValid then
+                    [ text title ]
+
+                 else
+                    [ text <| title ++ " INVALID HASH" ]
+                )
             ]
         , div
             [ HA.style "padding" "1.25rem"

--- a/frontend/src/ProposalMetadata.elm
+++ b/frontend/src/ProposalMetadata.elm
@@ -3,6 +3,7 @@ module ProposalMetadata exposing (Body, ProposalMetadata, decoder, encode, fromR
 {-| Helper module to handle proposals metadata following [CIP-108](https://cips.cardano.org/cip/CIP-0108).
 -}
 
+import Bytes.Comparable as Bytes
 import Json.Decode as JD exposing (Decoder, Value)
 import Json.Encode as JE
 
@@ -13,6 +14,7 @@ even if the metadata itself doesn’t follow CIP-108.
 -}
 type alias ProposalMetadata =
     { raw : String
+    , computedHash : String
     , body : Body
     }
 
@@ -51,9 +53,15 @@ decoder =
 -}
 fromRaw : String -> ProposalMetadata
 fromRaw raw =
+    let
+        computedHash =
+            Bytes.fromText raw
+                |> Bytes.blake2b256
+                |> Bytes.toHex
+    in
     JD.decodeString (JD.field "body" bodyDecoder) raw
-        |> Result.map (ProposalMetadata raw)
-        |> Result.withDefault (ProposalMetadata raw noBody)
+        |> Result.map (ProposalMetadata raw computedHash)
+        |> Result.withDefault (ProposalMetadata raw computedHash noBody)
 
 
 bodyDecoder : Decoder Body


### PR DESCRIPTION
When metadata is downloaded, we compute the hash of the raw metadata file.
If the hash doesn’t match the declared one on-chain, we display a warning.