### PR TITLE
Add env file example and tweak readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Then simply open the app at http://localhost:8000
 ```sh
 # Use a pre-built container hosted on GitHub Container Registry (GHCR)
 # The --env-file argument is optional, see backend/README.md
-docker run --rm -p 8000:8000 --env-file ../backend/.env ghcr.io/cardano-foundation/cardano-governance-voting-tool:main
+docker run --rm -p 8000:8000 --env-file ./backend/.env ghcr.io/cardano-foundation/cardano-governance-voting-tool:main
 ```
 
 Alternatively, you can build the container yourself.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,34 @@
+# Regular IPFS RPC config with basic auth
+IPFS_FORMAT=basic
+IPFS_RPC_URL=https://ipfs-rpc.mycompany.org/api/v0
+IPFS_USER_ID=user
+IPFS_PASSWORD=password
+IPFS_LABEL="Pre-configured IPFS server"
+IPFS_DESCRIPTION="Files will be stored using the pre-configured IPFS servers."
+
+# Alternative IPFS config using NMKR servers
+# IPFS_FORMAT=nmkr
+# IPFS_RPC_URL=https://studio-api.nmkr.io/v2/UploadToIpfs
+# IPFS_USER_ID=000000
+# IPFS_BEARER_TOKEN=ffffffffffffffffffffffffffffffff
+# IPFS_LABEL="Pre-configured IPFS server (sponsored by NMKR)"
+# IPFS_DESCRIPTION="Files will be stored using NMKR's IPFS servers."
+
+# Network config: 0 for Preview, 1 for Mainnet
+NETWORK_ID=0
+
+# Preconfiguration of some voters for fast selection
+PRECONFIGURED_VOTERS_JSON="[
+  { \"voterType\": \"DRep\"
+  , \"description\": \"Vote as a Delegated Representative\"
+  , \"govId\": \"drep1ydpfkyjxzeqvalf6fgvj7lznrk8kcmfnvy9hyl6gr6ez6wgsjaelx\"
+  },
+  { \"voterType\": \"CC Member\"
+  , \"description\": \"Vote as a Constitutional Committee Member\"
+  , \"govId\": \"cc_hot1qdnedkra2957t6xzzwygdgyefd5ctpe4asywauqhtzlu9qqkttvd9\"
+  },
+  { \"voterType\": \"SPO\"
+  , \"description\": \"Vote as a Stake Pool Operator\"
+  , \"govId\": \"pool1nqheyct9a0mxn80cwp9pd5guncfu3rzwqtmru0l94accz7gjcgl\"
+  }
+]"

--- a/backend/README.md
+++ b/backend/README.md
@@ -3,6 +3,7 @@ Minimalist server for Cardano governance uses
 ## Getting Started
 
 First create and modify the `.env` file containing the IPFS node access config.
+You can start by copying the the `.env.example`.
 You can either configure it as a regular IPFS RPC server with basic auth,
 or as NMKR server.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -3,7 +3,7 @@ Minimalist server for Cardano governance uses
 ## Getting Started
 
 First create and modify the `.env` file containing the IPFS node access config.
-You can start by copying the the `.env.example`.
+You can start by copying the `.env.example`.
 You can either configure it as a regular IPFS RPC server with basic auth,
 or as NMKR server.
 


### PR DESCRIPTION
### Changes

- added a `.env.example` to the backend directory
- added a note to the backend readme about `.env.example`
- changed a path in base readme running instructions

### Motivation

- I find that a `.env.example` is quite useful, and would have saved me a few mins of looking through the docs
- the running instructions assumed the path of `./container` rather than just being in the base repo directory, fixing this took me a few mins to figure out
  - I assume others may be caught out by this 