### PR TITLE
Upgrade elm deps

### DIFF
--- a/frontend/elm.json
+++ b/frontend/elm.json
@@ -22,9 +22,9 @@
             "elm/url": "1.0.0",
             "elm-cardano/bech32": "1.0.0",
             "elm-toulouse/cbor": "4.0.1",
-            "elmcraft/core-extra": "2.1.0",
-            "jxxcarlson/hex": "4.0.0",
-            "krisajenkins/remotedata": "6.0.1",
+            "elmcraft/core-extra": "2.2.0",
+            "jxxcarlson/hex": "4.0.1",
+            "krisajenkins/remotedata": "6.1.0",
             "lydell/elm-app-url": "1.0.4",
             "myrho/numeral-elm": "1.0.1",
             "turboMaCk/any-dict": "2.6.0"
@@ -35,8 +35,7 @@
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
-            "elm/virtual-dom": "1.0.3",
-            "elm-community/list-extra": "8.7.0",
+            "elm/virtual-dom": "1.0.4",
             "elm-toulouse/float16": "1.0.1",
             "myrho/elm-round": "1.0.5",
             "rtfeldman/elm-hex": "1.0.0"


### PR DESCRIPTION
Upgrading elm deps, including elm/virtual-dom 1.0.4 that fixes a potential xss threat via the `outerHTML` property.

- package upgrade: https://github.com/elm/virtual-dom/compare/1.0.3...1.0.4
- security threat: https://gist.github.com/lydell/a2c25a4257879c145fadd8622fa640f4

In practice this could only be triggered via malicious dependencies building html nodes. We didn’t have any, and an analysis of the package by ecosystem members didn’t reveal any.