### PR TITLE
Replace CardanoScan links with Cardano Explorer

### DIFF
--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -1336,7 +1336,7 @@ proposalCard { title, hashIsValid, abstract, actionType, linkUrl, linkHex, index
                             , HA.style "color" "#3182CE"
                             , HA.style "text-decoration" "underline"
                             , HA.style "cursor" "pointer"
-                            , HA.title "View on Cardanoscan (opens in new tab)"
+                            , HA.title "View on Cardano Explorer (opens in new tab)"
                             ]
                             [ text linkHex
                             , text <| "#" ++ String.fromInt index

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -2956,7 +2956,7 @@ viewProposalCardHelper wrapMsg networkId proposal =
                     "Proposal details not available"
 
         linkUrl =
-            cardanoScanActionUrl networkId proposal.id
+            cardanoExplorerActionUrl networkId proposal.id
 
         linkHex =
             Helper.shortenedHex 5 (Bytes.toHex proposal.id.transactionId)
@@ -3077,7 +3077,7 @@ viewSelectedProposal ctx { id, actionType, metadata, metadataUrl, metadataHash }
         [ div [ HA.class "flex items-center mb-4" ]
             [ Helper.sectionTitle "Pick a Proposal" ]
         , Helper.selectedProposalCard
-            [ Helper.proposalDetailsItem "Proposal ID" (cardanoScanActionLink ctx.networkId id)
+            [ Helper.proposalDetailsItem "Proposal ID" (cardanoExplorerActionLink ctx.networkId id)
             , Helper.proposalDetailsItem "Type" actionTypeDisplay
             , Helper.proposalDetailsItem "Title" (Html.span [ HA.style "font-weight" "500" ] [ text title ])
             , if hashIsValid then
@@ -3106,30 +3106,36 @@ viewSelectedProposal ctx { id, actionType, metadata, metadataUrl, metadataHash }
 
 
 
--- Helper function to generate CardanoScan URL
+-- Helper function to generate Cardano Explorer URL
 
 
-cardanoScanActionUrl : NetworkId -> ActionId -> String
-cardanoScanActionUrl networkId id =
+cardanoExplorerActionUrl : NetworkId -> ActionId -> String
+cardanoExplorerActionUrl networkId id =
     let
+        -- Format: {transactionId}{paddedGovActionIndex}
+        -- The governance action index should be zero-padded to 2 digits
+        paddedIndex =
+            String.padLeft 2 '0' (String.fromInt id.govActionIndex)
+        
+        governanceActionId =
+            (id.transactionId |> Bytes.toHex) ++ paddedIndex
+
         baseUrl =
             case networkId of
                 Mainnet ->
-                    "https://cardanoscan.io/govAction/"
+                    "https://explorer.cardano.org/governance-action/"
 
                 Testnet ->
-                    "https://preview.cardanoscan.io/govAction/"
+                    "https://explorer.cardano.org/preview/governance-action/"
     in
-    baseUrl
-        ++ (id.transactionId |> Bytes.toHex)
-        ++ (Bytes.toHex <| Bytes.fromBytes <| Cbor.Encode.encode (Cbor.Encode.int id.govActionIndex))
+    baseUrl ++ governanceActionId
 
 
-cardanoScanActionLink : NetworkId -> ActionId -> Html msg
-cardanoScanActionLink networkId id =
+cardanoExplorerActionLink : NetworkId -> ActionId -> Html msg
+cardanoExplorerActionLink networkId id =
     let
         url =
-            cardanoScanActionUrl networkId id
+            cardanoExplorerActionUrl networkId id
     in
     Html.a
         [ HA.href url

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -3112,13 +3112,8 @@ viewSelectedProposal ctx { id, actionType, metadata, metadataUrl, metadataHash }
 cardanoExplorerActionUrl : NetworkId -> ActionId -> String
 cardanoExplorerActionUrl networkId id =
     let
-        -- Format: {transactionId}{paddedGovActionIndex}
-        -- The governance action index should be zero-padded to 2 digits
-        paddedIndex =
-            String.padLeft 2 '0' (String.fromInt id.govActionIndex)
-
         governanceActionId =
-            (id.transactionId |> Bytes.toHex) ++ paddedIndex
+            Gov.idToBech32 (GovActionId id)
 
         baseUrl =
             case networkId of

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -3116,7 +3116,7 @@ cardanoExplorerActionUrl networkId id =
         -- The governance action index should be zero-padded to 2 digits
         paddedIndex =
             String.padLeft 2 '0' (String.fromInt id.govActionIndex)
-        
+
         governanceActionId =
             (id.transactionId |> Bytes.toHex) ++ paddedIndex
 

--- a/frontend/src/Page/Signing.elm
+++ b/frontend/src/Page/Signing.elm
@@ -573,15 +573,15 @@ view ctx model =
                                     , HA.style "flex-wrap" "wrap"
                                     ]
                                     [ let
-                                        cardanoScanBaseUrl =
+                                        cardanoExplorerTxUrl =
                                             case ctx.networkId of
                                                 Mainnet ->
-                                                    "https://cardanoscan.io/transaction/"
+                                                    "https://explorer.cardano.org/transaction?id=" ++ Bytes.toHex txId
 
                                                 Testnet ->
-                                                    "https://preview.cardanoscan.io/transaction/"
+                                                    "https://explorer.cardano.org/preview/transaction?id=" ++ Bytes.toHex txId
                                       in
-                                      Helper.externalLinkButton { url = cardanoScanBaseUrl ++ Bytes.toHex txId, label = "View on CardanoScan" }
+                                      Helper.externalLinkButton { url = cardanoExplorerTxUrl, label = "View on Cardano Explorer" }
                                     ]
                                 ]
                             ]


### PR DESCRIPTION
- Update governance action links to use explorer.cardano.org
- Update transaction links to use explorer.cardano.org
- Update tooltip text from 'Cardanoscan' to 'Cardano Explorer'