### PR TITLE
Filter out ratified proposals with Koios

### DIFF
--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -48,7 +48,7 @@ So this is how there is a mix of regular `(...) -> Cmd msg` and `ConcurrentTask 
 type alias ApiProvider msg =
     { loadProtocolParams : NetworkId -> (Result Http.Error ProtocolParams -> msg) -> Cmd msg
     , queryEpoch : NetworkId -> (Result Http.Error Int -> msg) -> Cmd msg
-    , loadGovProposals : NetworkId -> (Result Http.Error (List ActiveProposal) -> msg) -> Cmd msg
+    , loadGovProposals : NetworkId -> Int -> (Result Http.Error (List ActiveProposal) -> msg) -> Cmd msg
     , loadProposalMetadata : String -> ConcurrentTask String ProposalMetadata
     , retrieveTx : NetworkId -> Bytes TransactionId -> ConcurrentTask ConcurrentTask.Http.Error (Bytes Transaction)
     , getScriptInfo : NetworkId -> Bytes CredentialHash -> ConcurrentTask ConcurrentTask.Http.Error ScriptInfo
@@ -113,33 +113,35 @@ type alias ActiveProposal =
     , metadataUrl : String
     , metadataHash : String
     , epoch_validity : { start : Int, end : Int }
+    , ratified : Maybe Int
     , metadata : RemoteData String ProposalMetadata
     }
 
 
-ogmiosGovProposalsDecoder : Decoder (List ActiveProposal)
-ogmiosGovProposalsDecoder =
-    JD.field "result" <|
-        JD.list <|
-            JD.map6 ActiveProposal
-                (JD.map2
-                    (\id index ->
-                        { transactionId = Bytes.fromHexUnchecked id
-                        , govActionIndex = index
-                        }
-                    )
-                    (JD.at [ "proposal", "transaction", "id" ] JD.string)
-                    (JD.at [ "proposal", "index" ] JD.int)
+koiosGovProposalsDecoder : Decoder (List ActiveProposal)
+koiosGovProposalsDecoder =
+    JD.list <|
+        JD.map7 ActiveProposal
+            (JD.map2
+                (\id index ->
+                    { transactionId = Bytes.fromHexUnchecked id
+                    , govActionIndex = index
+                    }
                 )
-                (JD.at [ "action", "type" ] JD.string)
-                (JD.at [ "metadata", "url" ] JD.string)
-                (JD.at [ "metadata", "hash" ] JD.string)
-                (JD.map2
-                    (\start end -> { start = start, end = end })
-                    (JD.at [ "since", "epoch" ] JD.int)
-                    (JD.at [ "until", "epoch" ] JD.int)
-                )
-                (JD.succeed RemoteData.Loading)
+                (JD.field "proposal_tx_hash" JD.string)
+                (JD.field "proposal_index" JD.int)
+            )
+            (JD.field "proposal_type" JD.string)
+            (JD.field "meta_url" JD.string)
+            (JD.field "meta_hash" JD.string)
+            (JD.map2
+                (\start end -> { start = start, end = end })
+                (JD.field "proposed_epoch" JD.int)
+                -- TODO or is it expiration +-1 ?
+                (JD.field "expiration" JD.int)
+            )
+            (JD.field "ratified_epoch" <| JD.maybe JD.int)
+            (JD.succeed RemoteData.Loading)
 
 
 
@@ -461,19 +463,26 @@ defaultApiProvider =
 
     -- Get governance proposals via Koios
     , loadGovProposals =
-        \networkId toMsg ->
+        \networkId currentEpoch toMsg ->
+            let
+                selected_rows =
+                    [ "proposal_tx_hash"
+                    , "proposal_index"
+                    , "proposal_type"
+                    , "meta_url"
+                    , "meta_hash"
+                    , "proposed_epoch"
+                    , "expiration"
+                    , "ratified_epoch"
+                    ]
+                        |> String.join ","
+            in
             Http.request
-                { method = "POST"
-                , url = koiosUrl networkId ++ "/ogmios"
+                { method = "GET"
+                , url = koiosUrl networkId ++ "/proposal_list?select=" ++ selected_rows ++ "&expiration=gte." ++ String.fromInt currentEpoch
                 , headers = [ Http.header "Authorization" <| "Bearer " ++ koiosApiToken ]
-                , body =
-                    Http.jsonBody
-                        (JE.object
-                            [ ( "jsonrpc", JE.string "2.0" )
-                            , ( "method", JE.string "queryLedgerState/governanceProposals" )
-                            ]
-                        )
-                , expect = Http.expectJson toMsg ogmiosGovProposalsDecoder
+                , body = Http.emptyBody
+                , expect = Http.expectJson toMsg koiosGovProposalsDecoder
                 , timeout = Nothing
                 , tracker = Nothing
                 }

--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -431,25 +431,25 @@ viewActionTypeIcon actionType =
             ]
     in
     case actionType of
-        "treasuryWithdrawals" ->
+        "TreasuryWithdrawals" ->
             Html.span iconStyle [ text "💰" ]
 
-        "constitution" ->
+        "NewConstitution" ->
             Html.span iconStyle [ text "📜" ]
 
-        "constitutionalCommittee" ->
+        "NewCommittee" ->
             Html.span iconStyle [ text "👥" ]
 
-        "information" ->
+        "InfoAction" ->
             Html.span iconStyle [ text "ℹ️" ]
 
-        "noConfidence" ->
+        "NoConfidence" ->
             Html.span iconStyle [ text "❌" ]
 
-        "protocolParametersUpdate" ->
+        "ParameterChange" ->
             Html.span iconStyle [ text "⚙️" ]
 
-        "hardfork" ->
+        "HardForkInitiation" ->
             Html.span iconStyle [ text "🍴" ]
 
         _ ->

--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -1241,8 +1241,8 @@ showMoreButton hasMore visibleCount totalCount clickMsg =
 
 {-| Card for an individual proposal
 -}
-proposalCard : { title : String, hashIsValid : Bool, abstract : String, actionType : String, linkUrl : String, linkHex : String, index : Int } -> msg -> Html msg -> Html msg
-proposalCard { title, hashIsValid, abstract, actionType, linkUrl, linkHex, index } selectMsg actionIcon =
+proposalCard : { title : String, hashIsValid : Bool, isRatifying : Bool, abstract : String, actionType : String, linkUrl : String, linkHex : String, index : Int } -> msg -> Html msg -> Html msg
+proposalCard { title, hashIsValid, isRatifying, abstract, actionType, linkUrl, linkHex, index } selectMsg actionIcon =
     div
         [ HA.style "border" "1px solid #E2E8F0"
         , HA.style "border-radius" "0.75rem"
@@ -1272,12 +1272,12 @@ proposalCard { title, hashIsValid, abstract, actionType, linkUrl, linkHex, index
                 , HA.style "word-wrap" "break-word"
                 , HA.style "flex" "1"
                 ]
-                (if hashIsValid then
-                    [ text title ]
+                [ text title
+                , if hashIsValid then
+                    text ""
 
-                 else
-                    [ text title
-                    , Html.span
+                  else
+                    Html.span
                         [ HA.style "display" "inline-flex"
                         , HA.style "align-items" "center"
                         , HA.style "background-color" "#FEF2F2"
@@ -1291,8 +1291,23 @@ proposalCard { title, hashIsValid, abstract, actionType, linkUrl, linkHex, index
                         [ Html.span [] [ text "⚠️" ]
                         , text "INVALID HASH"
                         ]
-                    ]
-                )
+                , if isRatifying then
+                    Html.span
+                        [ HA.style "display" "inline-flex"
+                        , HA.style "align-items" "center"
+                        , HA.style "background-color" "#ACFCCD"
+                        , HA.style "color" "#437D5B"
+                        , HA.style "font-weight" "bold"
+                        , HA.style "padding" "0.25rem 0.5rem"
+                        , HA.style "border-radius" "0.375rem"
+                        , HA.style "font-size" "0.875rem"
+                        , HA.style "gap" "0.25rem"
+                        ]
+                        [ text "✓ in ratification" ]
+
+                  else
+                    text ""
+                ]
             ]
         , div
             [ HA.style "padding" "1.25rem"
@@ -1365,7 +1380,12 @@ proposalCard { title, hashIsValid, abstract, actionType, linkUrl, linkHex, index
                 [ HA.style "width" "100%"
                 , HA.style "margin-top" "1rem"
                 ]
-                "Select Proposal"
+                (if isRatifying then
+                    "Select Proposal ANYWAY"
+
+                 else
+                    "Select Proposal"
+                )
                 selectMsg
             ]
         ]

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -645,7 +645,7 @@ update msg model =
 
                 Ok epoch ->
                     ( { model | epoch = RemoteData.Success epoch }
-                    , Cmd.none
+                    , Api.defaultApiProvider.loadGovProposals model.networkId epoch GotProposals
                     )
 
         ( GotProposals result, _ ) ->
@@ -657,13 +657,16 @@ update msg model =
 
                 Ok activeProposals ->
                     let
-                        epochVisibility =
+                        currentEpoch =
                             RemoteData.withDefault 0 model.epoch
 
                         proposalsList =
                             List.map (\p -> ( Gov.actionIdToString p.id, p )) activeProposals
-                                -- only keep those that aren’t expired when we receive them
-                                |> List.filter (\( _, p ) -> p.epoch_validity.end >= epochVisibility)
+                                -- deduplicate proposals
+                                |> Dict.fromList
+                                |> Dict.toList
+                                -- only keep those that aren’t expired or already ratified when we receive them
+                                |> List.filter (\( _, p ) -> p.epoch_validity.end >= currentEpoch && p.ratified == Nothing)
 
                         completeReadProposalMetadataTask : ActiveProposal -> ConcurrentTask x TaskCompleted
                         completeReadProposalMetadataTask { id, metadataHash, metadataUrl } =
@@ -765,7 +768,6 @@ handleUrlChange route model =
                 , Cmd.batch
                     [ pushUrlCmd
                     , Api.defaultApiProvider.queryEpoch model.networkId GotEpoch
-                    , Api.defaultApiProvider.loadGovProposals model.networkId GotProposals
                     ]
                 )
 

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -665,8 +665,8 @@ update msg model =
                                 -- deduplicate proposals
                                 |> Dict.fromList
                                 |> Dict.toList
-                                -- only keep those that aren’t expired or already ratified when we receive them
-                                |> List.filter (\( _, p ) -> p.epoch_validity.end >= currentEpoch && p.ratified == Nothing)
+                                -- only keep those that aren’t expired when we receive them
+                                |> List.filter (\( _, p ) -> p.epoch_validity.end >= currentEpoch)
 
                         completeReadProposalMetadataTask : ActiveProposal -> ConcurrentTask x TaskCompleted
                         completeReadProposalMetadataTask { id, metadataHash, metadataUrl } =

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -2917,7 +2917,7 @@ viewProposalList ctx proposalsDict visibleCount =
             [ Helper.proposalListContainer
                 "Select a proposal to vote on"
                 totalProposalCount
-                (List.map (viewProposalCardHelper ctx.wrapMsg ctx.networkId) visibleProposals)
+                (List.map (viewProposalCardHelper ctx.wrapMsg ctx.networkId ctx.epoch) visibleProposals)
             , Helper.showMoreButton
                 hasMore
                 visibleCount
@@ -2926,8 +2926,8 @@ viewProposalList ctx proposalsDict visibleCount =
             ]
 
 
-viewProposalCardHelper : (Msg -> msg) -> NetworkId -> ActiveProposal -> Html msg
-viewProposalCardHelper wrapMsg networkId proposal =
+viewProposalCardHelper : (Msg -> msg) -> NetworkId -> Maybe Int -> ActiveProposal -> Html msg
+viewProposalCardHelper wrapMsg networkId currentEpoch proposal =
     let
         idString =
             Gov.actionIdToString proposal.id
@@ -2970,6 +2970,7 @@ viewProposalCardHelper wrapMsg networkId proposal =
     in
     Helper.proposalCard
         { hashIsValid = hashIsValid
+        , isRatifying = proposal.ratified == currentEpoch
         , title = title
         , abstract = abstract
         , actionType = proposal.actionType


### PR DESCRIPTION
This PR fixes issue #81 

The fix consists in using the Koios enpoint `proposal_list` instead of the equivalent Ogmios endpoint. We have additional information to filter the response and have a more efficient (smaller) request footprint.