### PR TITLE
Add a second wallet discovery after proposal loaded

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -684,7 +684,12 @@ update msg model =
                         | taskPool = newPool
                         , proposals = RemoteData.Success <| Dict.fromList proposalsList
                       }
-                    , Cmd.batch cmds
+                      -- Let’s also redo a wallet discovery,
+                      -- just to make sure all wallets have had the time to load,
+                      -- which should be the case by now.
+                      -- This is to prevent a situation where the browser extensions
+                      -- were not ready yet the first time around.
+                    , Cmd.batch (toWallet (Cip30.encodeRequest Cip30.discoverWallets) :: cmds)
                     )
 
         ( OnTaskProgress ( taskPool, cmd ), _ ) ->


### PR DESCRIPTION
This behavior is to prevent situations where the client browser extensions are a bit slow to load. One user reported this issue with the wallet connection button not showing. Redoing a wallet discovery after the proposals list was loaded should provide enough time for the browser extensions to have loaded, and doesn’t impact users for who the wallets had already loaded and/or connected. At least, I don’t think so.