### PR TITLE
Check that a wallet was detected before filling rationale

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -1170,6 +1170,7 @@ viewContent model =
             in
             Page.Preparation.view
                 { wrapMsg = PreparationPageMsg
+                , walletsDiscovered = model.walletsDiscovered
                 , loadedWallet = loadedWallet
                 , drepId = model.walletDrepId
                 , epoch = RemoteData.toMaybe model.epoch

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -3451,7 +3451,7 @@ viewRationaleStep ctx pickProposalStep storageConfigStep step =
             ( ( _, Done _ _ ), Done _ _, Done _ rationale ) ->
                 viewCompletedRationale rationale
 
-            ( ( _, _ ), Done _ _, _ ) ->
+            ( _, Done _ _, _ ) ->
                 div []
                     [ Helper.sectionTitle "Vote Rationale"
                     , Helper.stepNotAvailableCard [ text "Please pick a proposal first." ]

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -2451,6 +2451,7 @@ allPrepSteps { loadedWallet, costModels } m =
 -}
 type alias ViewContext msg =
     { wrapMsg : Msg -> msg
+    , walletsDiscovered : List Cip30.WalletDescriptor
     , loadedWallet : Maybe LoadedWallet
     , drepId : Maybe (Bytes CredentialHash)
     , epoch : Maybe Int
@@ -3428,11 +3429,17 @@ viewRationaleStep :
     -> Html msg
 viewRationaleStep ctx pickProposalStep storageConfigStep step =
     Html.map ctx.wrapMsg <|
-        case ( pickProposalStep, storageConfigStep, step ) of
-            ( Done _ _, Done _ _, Preparing form ) ->
+        case ( ( ctx.walletsDiscovered, pickProposalStep ), storageConfigStep, step ) of
+            ( ( [], _ ), _, _ ) ->
+                div []
+                    [ Helper.sectionTitle "Vote Rationale"
+                    , Helper.stepNotAvailableCard [ text "No Cardano wallet detected, you will not be able to create a transaction. Please make sure you are using the browser where your Cardano wallet is installed." ]
+                    ]
+
+            ( ( _, Done _ _ ), Done _ _, Preparing form ) ->
                 viewRationaleForm form
 
-            ( Done _ _, Done _ _, Validating _ _ ) ->
+            ( ( _, Done _ _ ), Done _ _, Validating _ _ ) ->
                 div []
                     [ Helper.sectionTitle "Vote Rationale"
                     , Helper.formContainer
@@ -3441,16 +3448,16 @@ viewRationaleStep ctx pickProposalStep storageConfigStep step =
                         ]
                     ]
 
-            ( Done _ _, Done _ _, Done _ rationale ) ->
+            ( ( _, Done _ _ ), Done _ _, Done _ rationale ) ->
                 viewCompletedRationale rationale
 
-            ( _, Done _ _, _ ) ->
+            ( ( _, _ ), Done _ _, _ ) ->
                 div []
                     [ Helper.sectionTitle "Vote Rationale"
                     , Helper.stepNotAvailableCard [ text "Please pick a proposal first." ]
                     ]
 
-            ( Done _ _, _, _ ) ->
+            ( ( _, Done _ _ ), _, _ ) ->
                 div []
                     [ Helper.sectionTitle "Vote Rationale"
                     , Helper.stepNotAvailableCard [ text "Please validate the IPFS config step first." ]


### PR DESCRIPTION
To prevent situations where users might start filling the rationale and realize later they can’t connect any wallet, because no wallet was detected in the browser, we prevent users from doing the rationale step if no wallet was detected.

This can avoid frustrating situations where a user might have to restart from scratch.