### PR TITLE
QoL improvements to make it quicker to vote

### DIFF
--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -13,7 +13,7 @@ module Helper exposing
     , proposalListContainer, showMoreButton, proposalCard, selectedProposalCard, proposalDetailsItem
     , storageConfigCard, storageMethodOption, storageProviderForm, storageProviderCard, storageConfigItem, addHeaderButton, storageHeaderInput
     , storageHeaderForm, storageInfoGrid, storageNotAvailableCard, storageUploadCard, uploadingSpinner, storageSuccessCard, fileInfoItem, externalLinkDisplay
-    , rationaleCard, rationaleMarkdownInput, rationaleTextArea, pdfAutogenCheckbox, voteNumberInput, referenceCard, referenceForm
+    , rationaleCard, checkbox, rationaleMarkdownInput, rationaleTextArea, pdfAutogenCheckbox, voteNumberInput, referenceCard, referenceForm
     , rationaleCompletedCard, optionalSection, formattedInternalVote, formattedReferences
     , stepNotAvailableCard, downloadJSONButton, authorsCard, addAuthorButton, codeSnippetBox, noAuthorsPlaceholder
     , signerCard, authorForm, labeledField, readOnlyField, signatureField, formButtonsRow, secondaryButton, primaryButton, loadSignatureButton
@@ -89,7 +89,7 @@ and are potentially useful in multiple places.
 
 # Rationale Components
 
-@docs rationaleCard, rationaleMarkdownInput, rationaleTextArea, pdfAutogenCheckbox, voteNumberInput, referenceCard, referenceForm
+@docs rationaleCard, checkbox, rationaleMarkdownInput, rationaleTextArea, pdfAutogenCheckbox, voteNumberInput, referenceCard, referenceForm
 @docs rationaleCompletedCard, optionalSection, formattedInternalVote, formattedReferences
 
 
@@ -1152,16 +1152,23 @@ scriptSignerSection additionalBytesPerSig feePerByte content =
 -}
 scriptSignerCheckbox : String -> Bool -> (Bool -> msg) -> Html msg
 scriptSignerCheckbox keyHex isChecked onCheckMsg =
+    checkbox { id = keyHex, label = " key hash: " ++ keyHex } isChecked onCheckMsg
+
+
+{-| Generic checkbox
+-}
+checkbox : { id : String, label : String } -> Bool -> (Bool -> msg) -> Html msg
+checkbox { id, label } isChecked onCheckMsg =
     Html.p []
         [ Html.input
             [ HA.type_ "checkbox"
-            , HA.id keyHex
-            , HA.name keyHex
+            , HA.id id
+            , HA.name id
             , HA.checked isChecked
             , onCheck onCheckMsg
             ]
             []
-        , Html.label [ HA.for keyHex ] [ text <| " key hash: " ++ keyHex ]
+        , Html.label [ HA.for id ] [ text <| label ]
         ]
 
 

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -57,6 +57,7 @@ import Cardano.Gov as Gov
 import Cardano.Transaction as Transaction exposing (Transaction)
 import Cardano.TxIntent
 import Cardano.Utxo as Utxo exposing (Output, TransactionId)
+import Cmd.Extra
 import ConcurrentTask exposing (ConcurrentTask)
 import ConcurrentTask.Extra
 import Dict exposing (Dict)
@@ -68,6 +69,7 @@ import Html.Attributes as HA
 import Html.Events exposing (preventDefaultOn)
 import Http
 import Json.Decode as JD exposing (Decoder, Value)
+import Json.Encode as JE
 import Page.Disclaimer
 import Page.MultisigRegistration
 import Page.Pdf
@@ -194,7 +196,9 @@ type Page
 
 
 type TaskCompleted
-    = GotProposalMetadataTask String (Result String ProposalMetadata)
+    = Ignore
+    | GotLastVoter (Maybe Gov.Id)
+    | GotProposalMetadataTask String (Result String ProposalMetadata)
     | PreparationTaskCompleted Page.Preparation.TaskCompleted
 
 
@@ -761,6 +765,17 @@ handleUrlChange route model =
                         , page = PreparationPage <| Page.Preparation.init model.ipfsPreconfig
                         , appUrl = appUrl
                     }
+
+                reloadLatestVoterTask : ConcurrentTask String (Maybe Gov.Id)
+                reloadLatestVoterTask =
+                    Storage.read { db = model.db, storeName = "app" } govIdDecoder { key = "lastVoter" }
+
+                govIdDecoder =
+                    JD.string |> JD.map Gov.idFromBech32
+
+                ( newTaskPool, reloadLatestVoterCmd ) =
+                    ConcurrentTask.map GotLastVoter reloadLatestVoterTask
+                        |> ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete }
             in
             if networkId /= model.networkId then
                 initHelper route
@@ -772,12 +787,21 @@ handleUrlChange route model =
                     }
 
             else if RemoteData.isSuccess model.proposals then
-                ( newModel, pushUrlCmd )
-
-            else
-                ( { newModel | proposals = RemoteData.Loading }
+                ( { newModel | taskPool = newTaskPool }
                 , Cmd.batch
                     [ pushUrlCmd
+                    , reloadLatestVoterCmd
+                    ]
+                )
+
+            else
+                ( { newModel
+                    | proposals = RemoteData.Loading
+                    , taskPool = newTaskPool
+                  }
+                , Cmd.batch
+                    [ pushUrlCmd
+                    , reloadLatestVoterCmd
                     , Api.defaultApiProvider.queryEpoch model.networkId GotEpoch
                     ]
                 )
@@ -974,10 +998,29 @@ updateModelWithPrepToParentMsg msgToParent model =
             , Cmd.none
             )
 
+        Just (Page.Preparation.CacheVoterGovId voterGovId) ->
+            let
+                encodeGovId id =
+                    JE.string <| Gov.idToBech32 id
+
+                writeGovIdToDb =
+                    Storage.write { db = model.db, storeName = "app" } encodeGovId { key = "lastVoter" } voterGovId
+                        |> ConcurrentTask.map (always Ignore)
+            in
+            ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete } writeGovIdToDb
+                |> Tuple.mapFirst (\newTaskPool -> { model | taskPool = newTaskPool })
+
         Just (Page.Preparation.RunTask task) ->
             ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete }
                 (ConcurrentTask.map PreparationTaskCompleted task)
                 |> Tuple.mapFirst (\newTaskPool -> { model | taskPool = newTaskPool })
+
+        Just (Page.Preparation.BatchToParent msg1 msg2) ->
+            updateModelWithPrepToParentMsg (Just msg1) model
+                |> (\( newModel, cmd1 ) ->
+                        updateModelWithPrepToParentMsg (Just msg2) newModel
+                            |> Tuple.mapSecond (\cmd2 -> Cmd.batch [ cmd1, cmd2 ])
+                   )
 
 
 {-| Helper function to reset the signing step of the Preparation.
@@ -1000,6 +1043,14 @@ handleCompletedTask response model =
 
         ( ConcurrentTask.UnexpectedError error, _ ) ->
             ( { model | errors = Debug.toString error :: model.errors }, Cmd.none )
+
+        ( ConcurrentTask.Success Ignore, _ ) ->
+            ( model, Cmd.none )
+
+        ( ConcurrentTask.Success (GotLastVoter maybeGovId), _ ) ->
+            ( model
+            , Cmd.Extra.perform <| PreparationPageMsg <| Page.Preparation.setLastVoter maybeGovId
+            )
 
         ( ConcurrentTask.Success (GotProposalMetadataTask id result), _ ) ->
             let

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -73,7 +73,7 @@ import Json.Encode as JE
 import Page.Disclaimer
 import Page.MultisigRegistration
 import Page.Pdf
-import Page.Preparation exposing (JsonLdContexts)
+import Page.Preparation exposing (JsonLdContexts, StorageConfig)
 import Page.Signing
 import Platform.Cmd as Cmd
 import ProposalMetadata exposing (ProposalMetadata)
@@ -198,6 +198,7 @@ type Page
 type TaskCompleted
     = Ignore
     | GotLastVoter (Maybe Gov.Id)
+    | GotLastStorageConfig Page.Preparation.StorageConfig
     | GotProposalMetadataTask String (Result String ProposalMetadata)
     | PreparationTaskCompleted Page.Preparation.TaskCompleted
 
@@ -773,9 +774,15 @@ handleUrlChange route model =
                 govIdDecoder =
                     JD.string |> JD.map Gov.idFromBech32
 
-                ( newTaskPool, reloadLatestVoterCmd ) =
-                    ConcurrentTask.map GotLastVoter reloadLatestVoterTask
-                        |> ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete }
+                reloadLatestStorageConfigTask : ConcurrentTask String StorageConfig
+                reloadLatestStorageConfigTask =
+                    Storage.read { db = model.db, storeName = "app" } Page.Preparation.storageConfigDecoder { key = "lastStorageConfig" }
+
+                ( newTaskPool, taskCmds ) =
+                    ConcurrentTask.Extra.attemptEach { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete }
+                        [ ConcurrentTask.map GotLastVoter reloadLatestVoterTask
+                        , ConcurrentTask.map GotLastStorageConfig reloadLatestStorageConfigTask
+                        ]
             in
             if networkId /= model.networkId then
                 initHelper route
@@ -788,10 +795,7 @@ handleUrlChange route model =
 
             else if RemoteData.isSuccess model.proposals then
                 ( { newModel | taskPool = newTaskPool }
-                , Cmd.batch
-                    [ pushUrlCmd
-                    , reloadLatestVoterCmd
-                    ]
+                , Cmd.batch (pushUrlCmd :: taskCmds)
                 )
 
             else
@@ -800,10 +804,10 @@ handleUrlChange route model =
                     , taskPool = newTaskPool
                   }
                 , Cmd.batch
-                    [ pushUrlCmd
-                    , reloadLatestVoterCmd
-                    , Api.defaultApiProvider.queryEpoch model.networkId GotEpoch
-                    ]
+                    (pushUrlCmd
+                        :: Api.defaultApiProvider.queryEpoch model.networkId GotEpoch
+                        :: taskCmds
+                    )
                 )
 
         RouteSigning { networkId, expectedSigners, tx } ->
@@ -1010,6 +1014,15 @@ updateModelWithPrepToParentMsg msgToParent model =
             ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete } writeGovIdToDb
                 |> Tuple.mapFirst (\newTaskPool -> { model | taskPool = newTaskPool })
 
+        Just (Page.Preparation.CacheStorageConfig storageConfig) ->
+            let
+                writeStorageConfigToDb =
+                    Storage.write { db = model.db, storeName = "app" } Page.Preparation.encodeStorageConfig { key = "lastStorageConfig" } storageConfig
+                        |> ConcurrentTask.map (always Ignore)
+            in
+            ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete } writeStorageConfigToDb
+                |> Tuple.mapFirst (\newTaskPool -> { model | taskPool = newTaskPool })
+
         Just (Page.Preparation.RunTask task) ->
             ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete }
                 (ConcurrentTask.map PreparationTaskCompleted task)
@@ -1051,6 +1064,18 @@ handleCompletedTask response model =
             ( model
             , Cmd.Extra.perform <| PreparationPageMsg <| Page.Preparation.setLastVoter maybeGovId
             )
+
+        ( ConcurrentTask.Success (GotLastStorageConfig storageConfig), PreparationPage pageModel ) ->
+            let
+                ( newPageModel, pageMsg ) =
+                    Page.Preparation.setLastStorageConfig storageConfig pageModel
+            in
+            ( { model | page = PreparationPage newPageModel }
+            , Cmd.Extra.perform <| PreparationPageMsg pageMsg
+            )
+
+        ( ConcurrentTask.Success (GotLastStorageConfig _), _ ) ->
+            ( model, Cmd.none )
 
         ( ConcurrentTask.Success (GotProposalMetadataTask id result), _ ) ->
             let

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -1,4 +1,4 @@
-module Page.Preparation exposing (InternalVote, JsonLdContexts, LoadedWallet, Model, Msg, MsgToParent(..), Rationale, Reference, ReferenceType(..), TaskCompleted, UpdateContext, ViewContext, handleTaskCompleted, init, noInternalVote, pinPdfFile, pinRationaleFile, update, view)
+module Page.Preparation exposing (InternalVote, JsonLdContexts, LoadedWallet, Model, Msg, MsgToParent(..), Rationale, Reference, ReferenceType(..), TaskCompleted, UpdateContext, ViewContext, handleTaskCompleted, init, noInternalVote, pinPdfFile, pinRationaleFile, setLastVoter, update, view)
 
 {-| This module handles the complete vote preparation workflow, from identifying
 the voter to signing the transaction, which is handled by another page.
@@ -404,7 +404,9 @@ type MsgToParent
     | CacheDrepInfo DrepInfo
     | CacheCcInfo CcInfo
     | CachePoolInfo PoolInfo
+    | CacheVoterGovId Gov.Id
     | RunTask (ConcurrentTask String TaskCompleted)
+    | BatchToParent MsgToParent MsgToParent
 
 
 {-| Results from asynchronous tasks:
@@ -561,11 +563,12 @@ innerUpdate ctx msg model =
             case model.voterStep of
                 Preparing form ->
                     let
-                        ( newVoterStep, cmds, toParent ) =
+                        ( newVoterStep, toParent ) =
                             confirmVoter ctx form model.someRefUtxos
+                                |> saveValidVoter
                     in
                     ( { model | voterStep = newVoterStep }
-                    , Cmd.map ctx.wrapMsg cmds
+                    , Cmd.none
                     , toParent
                     )
 
@@ -1248,6 +1251,13 @@ handleTaskCompleted task (Model model) =
 -- Voter Step
 
 
+setLastVoter : Maybe Gov.Id -> Msg
+setLastVoter maybeGovId =
+    Maybe.map Gov.idToBech32 maybeGovId
+        |> Maybe.withDefault ""
+        |> VoterGovIdChange
+
+
 updateVoterForm : (VoterPreparationForm -> VoterPreparationForm) -> InnerModel -> InnerModel
 updateVoterForm f ({ voterStep } as model) =
     case voterStep of
@@ -1443,12 +1453,29 @@ checkGovId ctx str =
                         }
 
 
-confirmVoter : UpdateContext msg -> VoterPreparationForm -> Utxo.RefDict Output -> ( Step VoterPreparationForm Witness.Voter Witness.Voter, Cmd Msg, Maybe MsgToParent )
+saveValidVoter : ( Step VoterPreparationForm Witness.Voter Witness.Voter, Maybe MsgToParent ) -> ( Step VoterPreparationForm Witness.Voter Witness.Voter, Maybe MsgToParent )
+saveValidVoter ( step, msgToParent ) =
+    case step of
+        Done form _ ->
+            case ( form.govId, msgToParent ) of
+                ( Just govId, Nothing ) ->
+                    ( step, Just <| CacheVoterGovId govId )
+
+                ( Just govId, Just msg ) ->
+                    ( step, Just <| BatchToParent msg <| CacheVoterGovId govId )
+
+                ( Nothing, _ ) ->
+                    ( step, msgToParent )
+
+        _ ->
+            ( step, msgToParent )
+
+
+confirmVoter : UpdateContext msg -> VoterPreparationForm -> Utxo.RefDict Output -> ( Step VoterPreparationForm Witness.Voter Witness.Voter, Maybe MsgToParent )
 confirmVoter ctx form loadedRefUtxos =
     let
         justError errorMsg =
             ( Preparing { form | error = Just errorMsg }
-            , Cmd.none
             , Nothing
             )
     in
@@ -1464,19 +1491,16 @@ confirmVoter ctx form loadedRefUtxos =
 
         Just (PoolId poolId) ->
             ( Done form <| Witness.WithPoolCred poolId
-            , Cmd.none
             , Nothing
             )
 
         Just (DrepId (VKeyHash keyHash)) ->
             ( Done form <| Witness.WithDrepCred (Witness.WithKey keyHash)
-            , Cmd.none
             , Nothing
             )
 
         Just (CcHotCredId (VKeyHash keyHash)) ->
             ( Done form <| Witness.WithCommitteeHotCred (Witness.WithKey keyHash)
-            , Cmd.none
             , Nothing
             )
 
@@ -1509,12 +1533,11 @@ confirmVoter ctx form loadedRefUtxos =
                     validateScriptVoter ctx form loadedRefUtxos Witness.WithCommitteeHotCred scriptInfo
 
 
-validateScriptVoter : UpdateContext msg -> VoterPreparationForm -> Utxo.RefDict Output -> (Witness.Credential -> Witness.Voter) -> ScriptInfo -> ( Step VoterPreparationForm Witness.Voter Witness.Voter, Cmd Msg, Maybe MsgToParent )
+validateScriptVoter : UpdateContext msg -> VoterPreparationForm -> Utxo.RefDict Output -> (Witness.Credential -> Witness.Voter) -> ScriptInfo -> ( Step VoterPreparationForm Witness.Voter Witness.Voter, Maybe MsgToParent )
 validateScriptVoter ctx form loadedRefUtxos toVoter scriptInfo =
     let
         justError errorMsg =
             ( Preparing { form | error = Just errorMsg }
-            , Cmd.none
             , Nothing
             )
     in
@@ -1532,7 +1555,6 @@ validateScriptVoter ctx form loadedRefUtxos toVoter scriptInfo =
                                 }
                         in
                         ( Done { form | error = Nothing } <| toVoter <| Witness.WithScript scriptInfo.scriptHash <| Witness.Native witness
-                        , Cmd.none
                         , Nothing
                         )
 
@@ -1549,7 +1571,6 @@ validateScriptVoter ctx form loadedRefUtxos toVoter scriptInfo =
                             }
                     in
                     ( Done { form | error = Nothing } <| toVoter <| Witness.WithScript scriptInfo.scriptHash <| Witness.Plutus witness
-                    , Cmd.none
                     , Nothing
                     )
 
@@ -1571,13 +1592,11 @@ validateScriptVoter ctx form loadedRefUtxos toVoter scriptInfo =
                     in
                     if Dict.Any.member outputRef loadedRefUtxos then
                         ( Done { form | error = Nothing } voter
-                        , Cmd.none
                         , Nothing
                         )
 
                     else
                         ( Validating form voter
-                        , Cmd.none
                         , Api.defaultApiProvider.retrieveTx ctx.networkId outputRef.transactionId
                             |> Storage.cacheWrap
                                 { db = ctx.db, storeName = "tx" }
@@ -1592,7 +1611,7 @@ validateScriptVoter ctx form loadedRefUtxos toVoter scriptInfo =
                         )
 
                 Script.Plutus _ ->
-                    Debug.todo "Handle Plutus script case"
+                    justError "This Plutus script cannot be supported automatically. Please open an issue on GitHub describing how your Plutus script works."
 
 
 keepOnlyExpectedSigners : Dict String { expected : Bool, key : Bytes CredentialHash } -> List (Bytes CredentialHash)

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -1,4 +1,4 @@
-module Page.Preparation exposing (InternalVote, JsonLdContexts, LoadedWallet, Model, Msg, MsgToParent(..), Rationale, Reference, ReferenceType(..), TaskCompleted, UpdateContext, ViewContext, handleTaskCompleted, init, noInternalVote, pinPdfFile, pinRationaleFile, setLastVoter, update, view)
+module Page.Preparation exposing (InternalVote, JsonLdContexts, LoadedWallet, Model, Msg, MsgToParent(..), Rationale, Reference, ReferenceType(..), StorageConfig, TaskCompleted, UpdateContext, ViewContext, encodeStorageConfig, handleTaskCompleted, init, noInternalVote, pinPdfFile, pinRationaleFile, setLastStorageConfig, setLastVoter, storageConfigDecoder, update, view)
 
 {-| This module handles the complete vote preparation workflow, from identifying
 the voter to signing the transaction, which is handled by another page.
@@ -349,6 +349,91 @@ type StorageConfig
     | UseCustomIpfs { label : String, description : String, ipfsServer : String, headers : List ( String, String ) }
 
 
+encodeStorageConfig : StorageConfig -> JE.Value
+encodeStorageConfig config =
+    case config of
+        UsePreconfigIpfs { label, description } ->
+            JE.object
+                [ ( "storageType", JE.string "UsePreconfigIpfs" )
+                , ( "label", JE.string label )
+                , ( "description", JE.string description )
+                ]
+
+        UseBlockfrostIpfs { label, description, projectId } ->
+            JE.object
+                [ ( "storageType", JE.string "UseBlockfrostIpfs" )
+                , ( "label", JE.string label )
+                , ( "description", JE.string description )
+                , ( "projectId", JE.string projectId )
+                ]
+
+        UseNmkrIpfs { label, description, userId, apiToken } ->
+            JE.object
+                [ ( "storageType", JE.string "UseNmkrIpfs" )
+                , ( "label", JE.string label )
+                , ( "description", JE.string description )
+                , ( "userId", JE.string userId )
+                , ( "apiToken", JE.string apiToken )
+                ]
+
+        UseCustomIpfs { label, description, ipfsServer, headers } ->
+            JE.object
+                [ ( "storageType", JE.string "UseCustomIpfs" )
+                , ( "label", JE.string label )
+                , ( "description", JE.string description )
+                , ( "ipfsServer", JE.string ipfsServer )
+                , ( "headers", JE.list encodeHttpHeader headers )
+                ]
+
+
+encodeHttpHeader : ( String, String ) -> JE.Value
+encodeHttpHeader ( name, value ) =
+    JE.object [ ( "name", JE.string name ), ( "value", JE.string value ) ]
+
+
+httpHeaderDecoder : JD.Decoder ( String, String )
+httpHeaderDecoder =
+    JD.map2 Tuple.pair
+        (JD.field "name" JD.string)
+        (JD.field "value" JD.string)
+
+
+storageConfigDecoder : JD.Decoder StorageConfig
+storageConfigDecoder =
+    JD.field "storageType" JD.string
+        |> JD.andThen
+            (\storageType ->
+                case storageType of
+                    "UsePreconfigIpfs" ->
+                        JD.map2 (\label description -> UsePreconfigIpfs { label = label, description = description })
+                            (JD.field "label" JD.string)
+                            (JD.field "description" JD.string)
+
+                    "UseBlockfrostIpfs" ->
+                        JD.map3 (\label description projectId -> UseBlockfrostIpfs { label = label, description = description, projectId = projectId })
+                            (JD.field "label" JD.string)
+                            (JD.field "description" JD.string)
+                            (JD.field "projectId" JD.string)
+
+                    "UseNmkrIpfs" ->
+                        JD.map4 (\label description userId apiToken -> UseNmkrIpfs { label = label, description = description, userId = userId, apiToken = apiToken })
+                            (JD.field "label" JD.string)
+                            (JD.field "description" JD.string)
+                            (JD.field "userId" JD.string)
+                            (JD.field "apiToken" JD.string)
+
+                    "UseCustomIpfs" ->
+                        JD.map4 (\label description ipfsServer headers -> UseCustomIpfs { label = label, description = description, ipfsServer = ipfsServer, headers = headers })
+                            (JD.field "label" JD.string)
+                            (JD.field "description" JD.string)
+                            (JD.field "ipfsServer" JD.string)
+                            (JD.field "headers" (JD.list httpHeaderDecoder))
+
+                    _ ->
+                        JD.fail "Unknown storage type"
+            )
+
+
 type alias Storage =
     { jsonFile : IpfsFile
     }
@@ -405,6 +490,7 @@ type MsgToParent
     | CacheCcInfo CcInfo
     | CachePoolInfo PoolInfo
     | CacheVoterGovId Gov.Id
+    | CacheStorageConfig StorageConfig
     | RunTask (ConcurrentTask String TaskCompleted)
     | BatchToParent MsgToParent MsgToParent
 
@@ -757,7 +843,7 @@ innerUpdate ctx msg model =
                             -- and return a "Validating" step instead of a "Done" step.
                             ( { model | storageConfigStep = Done { form | error = Nothing } storageConfig }
                             , Cmd.none
-                            , Nothing
+                            , Just <| CacheStorageConfig storageConfig
                             )
 
                         Err error ->
@@ -1651,6 +1737,40 @@ utxoRefFromStr str =
 
 
 -- Storage Configuration Step
+
+
+setLastStorageConfig : StorageConfig -> Model -> ( Model, Msg )
+setLastStorageConfig storageConfig (Model innerModel) =
+    let
+        form =
+            case storageConfig of
+                UsePreconfigIpfs labelAndDescription ->
+                    initStorageForm labelAndDescription
+
+                UseBlockfrostIpfs { label, description, projectId } ->
+                    let
+                        empty =
+                            initStorageForm { label = label, description = description }
+                    in
+                    { empty | blockfrostProjectId = projectId }
+
+                UseNmkrIpfs { label, description, userId, apiToken } ->
+                    let
+                        empty =
+                            initStorageForm { label = label, description = description }
+                    in
+                    { empty | nmkrUserId = userId, nmkrApiToken = apiToken }
+
+                UseCustomIpfs { label, description, ipfsServer, headers } ->
+                    let
+                        empty =
+                            initStorageForm { label = label, description = description }
+                    in
+                    { empty | ipfsServer = ipfsServer, headers = headers }
+    in
+    ( Model { innerModel | storageConfigStep = Preparing form }
+    , ValidateStorageConfigButtonClicked
+    )
 
 
 updateStorageConfigForm : (StorageForm -> StorageForm) -> InnerModel -> InnerModel

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -119,7 +119,7 @@ init ipfsPreconfig =
         { someRefUtxos = Utxo.emptyRefDict
         , voterStep = Preparing initVoterForm
         , pickProposalStep = Preparing {}
-        , storageConfigStep = Preparing (initStorageForm ipfsPreconfig)
+        , storageConfigStep = Done (initStorageForm ipfsPreconfig) (UsePreconfigIpfs ipfsPreconfig)
         , rationaleCreationStep = Preparing initRationaleForm
         , rationaleSignatureStep = Preparing initRationaleSignatureForm
         , permanentStorageStep = Preparing { error = Nothing }

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -166,6 +166,7 @@ type alias RationaleForm =
     { summary : String
     , pdfAutogen : Bool
     , rationaleStatement : MarkdownForm
+    , optionalFieldsAreVisible : Bool
     , precedentDiscussion : MarkdownForm
     , counterArgumentDiscussion : MarkdownForm
     , conclusion : MarkdownForm
@@ -203,6 +204,7 @@ initRationaleForm =
     { summary = ""
     , pdfAutogen = True
     , rationaleStatement = ""
+    , optionalFieldsAreVisible = False
     , precedentDiscussion = ""
     , counterArgumentDiscussion = ""
     , conclusion = ""
@@ -536,6 +538,7 @@ type Msg
     | RationaleSummaryChange String
     | TogglePdfAutogen Bool
     | RationaleStatementChange String
+    | ToggleOptionalFieldsVisibility Bool
     | PrecedentDiscussionChange String
     | CounterArgumentChange String
     | ConclusionChange String
@@ -880,6 +883,12 @@ innerUpdate ctx msg model =
 
         RationaleStatementChange statement ->
             ( updateRationaleForm (\form -> { form | rationaleStatement = statement }) model
+            , Cmd.none
+            , Nothing
+            )
+
+        ToggleOptionalFieldsVisibility checked ->
+            ( updateRationaleForm (\form -> { form | optionalFieldsAreVisible = checked }) model
             , Cmd.none
             , Nothing
             )
@@ -3617,24 +3626,34 @@ viewRationaleForm form =
                 "Fully describe your rationale, with your arguments in full details. Use markdown with heading level 2 (##) or higher."
                 (viewStatementInput form.pdfAutogen form.rationaleStatement)
             , Helper.rationaleCard
-                "Precedent Discussion"
-                "Optional: Discuss what you feel is relevant precedent."
-                (Helper.rationaleMarkdownInput form.precedentDiscussion PrecedentDiscussionChange)
-            , Helper.rationaleCard
-                "Counter Argument Discussion"
-                "Optional: Discuss significant counter arguments to your position."
-                (Helper.rationaleMarkdownInput form.counterArgumentDiscussion CounterArgumentChange)
-            , Helper.rationaleCard
-                "Conclusion"
-                "Optional: Final thoughts on your position."
-                (Helper.rationaleTextArea ConclusionChange Nothing form.conclusion)
-            , Helper.rationaleCard
-                "Internal Vote"
-                "If you vote as a group, you can report the group internal votes."
-                (viewInternalVoteInput form.internalVote)
-            , Helper.referenceCard
-                (List.indexedMap viewOneRefForm form.references)
-                AddRefButtonClicked
+                "Optional Fields"
+                ""
+                (Helper.checkbox { id = "optional-fields", label = " Show optional fields" } form.optionalFieldsAreVisible ToggleOptionalFieldsVisibility)
+            , if form.optionalFieldsAreVisible then
+                div []
+                    [ Helper.rationaleCard
+                        "Precedent Discussion"
+                        "Optional: Discuss what you feel is relevant precedent."
+                        (Helper.rationaleMarkdownInput form.precedentDiscussion PrecedentDiscussionChange)
+                    , Helper.rationaleCard
+                        "Counter Argument Discussion"
+                        "Optional: Discuss significant counter arguments to your position."
+                        (Helper.rationaleMarkdownInput form.counterArgumentDiscussion CounterArgumentChange)
+                    , Helper.rationaleCard
+                        "Conclusion"
+                        "Optional: Final thoughts on your position."
+                        (Helper.rationaleTextArea ConclusionChange Nothing form.conclusion)
+                    , Helper.rationaleCard
+                        "Internal Vote"
+                        "If you vote as a group, you can report the group internal votes."
+                        (viewInternalVoteInput form.internalVote)
+                    , Helper.referenceCard
+                        (List.indexedMap viewOneRefForm form.references)
+                        AddRefButtonClicked
+                    ]
+
+              else
+                text ""
             ]
         , Html.p [ HA.class "mt-6" ] [ Helper.viewButton "Confirm rationale" ValidateRationaleButtonClicked ]
         , viewError form.error

--- a/frontend/src/Storage.elm
+++ b/frontend/src/Storage.elm
@@ -1,4 +1,4 @@
-module Storage exposing (cacheWrap)
+module Storage exposing (cacheWrap, read, write)
 
 {-| Helper module to store and retrieve data from an in-browser database.
 -}

--- a/frontend/static/index.html
+++ b/frontend/static/index.html
@@ -57,8 +57,8 @@
 
         // Initialize the main Elm app
         const db = await Storage.init({
-            version: 2,
-            storeNames: ["proposalMetadata", "tx", "scriptInfo"],
+            version: 3,
+            storeNames: ["proposalMetadata", "tx", "scriptInfo", "app"],
         });
         var mainApp = Elm.Main.init({
             node: document.getElementById("main-app"),


### PR DESCRIPTION
This PR is basically in response to feedback saying the app is to verbose and long to use. Like this https://x.com/jasonappleton/status/1946892984902881701

These are changes basically making it faster to vote with the tool. There are 3 changes:

1. The latest confirmed voter is saved and reloaded when the page is loading. So you just have to click on "Confirm voter" now. No need to re-paste your gov ID.
2. Same for the storage configuration. Your last storage config is reloaded and pre-confirmed. Also by default the pre-configured first option is selected and confirmed. That’s one less button to push.
3. Optional rational fields are hidden by default, with a toggle to display them. It’s less scrolling for 99% of voters just providing summary and rationale.

<img width="863" height="441" alt="image" src="https://github.com/user-attachments/assets/0d30904e-fd42-4787-bcc2-9440a3331f44" />
