### PR TITLE
Fix proposol end of visibility and voters local db reload error

### DIFF
--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -479,7 +479,7 @@ defaultApiProvider =
             in
             Http.request
                 { method = "GET"
-                , url = koiosUrl networkId ++ "/proposal_list?select=" ++ selected_rows ++ "&expiration=gte." ++ String.fromInt currentEpoch
+                , url = koiosUrl networkId ++ "/proposal_list?select=" ++ selected_rows ++ "&expiration=gt." ++ String.fromInt currentEpoch
                 , headers = [ Http.header "Authorization" <| "Bearer " ++ koiosApiToken ]
                 , body = Http.emptyBody
                 , expect = Http.expectJson toMsg koiosGovProposalsDecoder

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -770,6 +770,7 @@ handleUrlChange route model =
                 reloadLatestVoterTask : ConcurrentTask String (Maybe Gov.Id)
                 reloadLatestVoterTask =
                     Storage.read { db = model.db, storeName = "app" } govIdDecoder { key = "lastVoter" }
+                        |> ConcurrentTask.onError (\_ -> ConcurrentTask.succeed Nothing)
 
                 govIdDecoder =
                     JD.string |> JD.map Gov.idFromBech32
@@ -777,6 +778,7 @@ handleUrlChange route model =
                 reloadLatestStorageConfigTask : ConcurrentTask String StorageConfig
                 reloadLatestStorageConfigTask =
                     Storage.read { db = model.db, storeName = "app" } Page.Preparation.storageConfigDecoder { key = "lastStorageConfig" }
+                        |> ConcurrentTask.onError (\_ -> ConcurrentTask.succeed <| Page.Preparation.initStorageConfig model.ipfsPreconfig)
 
                 ( newTaskPool, taskCmds ) =
                     ConcurrentTask.Extra.attemptEach { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete }

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -667,7 +667,7 @@ update msg model =
 
                         isDropped p =
                             -- has expired
-                            (p.epoch_validity.end < currentEpoch)
+                            (p.epoch_validity.end <= currentEpoch)
                                 -- or was enacted (1 epoch after marked ratified by Koios)
                                 || (Maybe.withDefault False <| Maybe.map (\ratifiedEpoch -> currentEpoch > ratifiedEpoch) p.ratified)
 

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -1,4 +1,4 @@
-module Page.Preparation exposing (InternalVote, JsonLdContexts, LoadedWallet, Model, Msg, MsgToParent(..), Rationale, Reference, ReferenceType(..), StorageConfig, TaskCompleted, UpdateContext, ViewContext, encodeStorageConfig, handleTaskCompleted, init, noInternalVote, pinPdfFile, pinRationaleFile, setLastStorageConfig, setLastVoter, storageConfigDecoder, update, view)
+module Page.Preparation exposing (InternalVote, JsonLdContexts, LoadedWallet, Model, Msg, MsgToParent(..), Rationale, Reference, ReferenceType(..), StorageConfig, TaskCompleted, UpdateContext, ViewContext, encodeStorageConfig, handleTaskCompleted, init, initStorageConfig, noInternalVote, pinPdfFile, pinRationaleFile, setLastStorageConfig, setLastVoter, storageConfigDecoder, update, view)
 
 {-| This module handles the complete vote preparation workflow, from identifying
 the voter to signing the transaction, which is handled by another page.
@@ -349,6 +349,13 @@ type StorageConfig
     | UseBlockfrostIpfs { label : String, description : String, projectId : String }
     | UseNmkrIpfs { label : String, description : String, userId : String, apiToken : String }
     | UseCustomIpfs { label : String, description : String, ipfsServer : String, headers : List ( String, String ) }
+
+
+{-| Initialize the default storage config.
+-}
+initStorageConfig : { label : String, description : String } -> StorageConfig
+initStorageConfig { label, description } =
+    UsePreconfigIpfs { label = label, description = description }
 
 
 encodeStorageConfig : StorageConfig -> JE.Value

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -3045,12 +3045,12 @@ viewProposalList ctx proposalsDict visibleCount =
 
     else
         let
-            epochVisibility =
+            currentEpoch =
                 Maybe.withDefault 0 ctx.epoch
 
             allProposals =
                 Dict.values proposalsDict
-                    |> List.filter (\p -> p.epoch_validity.end >= epochVisibility)
+                    |> List.filter (\p -> p.epoch_validity.end > currentEpoch)
 
             totalProposalCount =
                 List.length allProposals


### PR DESCRIPTION
This is a small fix PR, address 2 issues introduced recently.

1. In PR #82 we switched from an ogmios endpoint to a koios endpoint. It seems the semantics for the epoch number marking the end of proposal validity changed, so we had an off-by-one error and continued to display expired proposals for one epoch. The current one still being showed is Gov Tools budget info action. The off-by-one error is now fixed.
2. In PR #92 we added local db of last used voter and ipfs config. But when loading the app for the first time with this upgrade, it would show at the bottom of the page an error for not finding that info in local db. Now we just ignore it if the local db read did not find such info.