### PR TITLE
Fix the voter loading error fix

### DIFF
--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -672,14 +672,20 @@ innerUpdate ctx msg model =
                     ( model, Cmd.none, Nothing )
 
         VoterGovIdChange govIdStr ->
-            case checkGovId ctx govIdStr of
-                Err error ->
+            case ( govIdStr, checkGovId ctx govIdStr ) of
+                ( "", _ ) ->
+                    ( updateVoterForm (\_ -> initVoterForm) model
+                    , Cmd.none
+                    , Nothing
+                    )
+
+                ( _, Err error ) ->
                     ( updateVoterForm (\_ -> { initVoterForm | error = Just error }) model
                     , Cmd.none
                     , Nothing
                     )
 
-                Ok { govId, scriptInfo, expectedSigners, drepInfo, ccInfo, poolInfo, cmd, msgToParent } ->
+                ( _, Ok { govId, scriptInfo, expectedSigners, drepInfo, ccInfo, poolInfo, cmd, msgToParent } ) ->
                     ( updateVoterForm
                         (\_ ->
                             { initVoterForm


### PR DESCRIPTION
Yeah, so my fix the other day in #97 created another follow up error ... sorry.
Instead of raising a loading error for the task trying to load a non-existent voter ID, it now default to the empty gov id string, but this triggers a CIP-129 parsing error later ...
Now we detect if the change is the empty string, we just reset the field.