### PR TITLE
Multi-vote

### DIFF
--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -10,7 +10,7 @@ module Helper exposing
     , viewStepWithCircle, viewPageHeader
     , PreconfVoter, viewVoterGrid, viewVoterCard, voterCustomCard, votingPowerDisplay, scriptInfoContainer, viewVoterCredDetails, viewVoterDetailsItem, viewCredInfo
     , viewUtxoRefForm, scriptSignerSection, scriptSignerCheckbox, viewIdentifiedVoterCard, viewVoterInfoItem
-    , proposalListContainer, showMoreButton, proposalCard, selectedProposalCard, proposalDetailsItem
+    , proposalListContainer, showMoreButton, proposalCard, selectedProposalCard, proposalDetailsItem, viewProposalsListInCart
     , storageConfigCard, storageMethodOption, storageProviderForm, storageProviderCard, storageConfigItem, addHeaderButton, storageHeaderInput
     , storageHeaderForm, storageInfoGrid, storageNotAvailableCard, storageUploadCard, uploadingSpinner, storageSuccessCard, fileInfoItem, externalLinkDisplay
     , rationaleCard, checkbox, rationaleMarkdownInput, rationaleTextArea, pdfAutogenCheckbox, voteNumberInput, referenceCard, referenceForm
@@ -78,7 +78,7 @@ and are potentially useful in multiple places.
 
 # Proposal Selection Components
 
-@docs proposalListContainer, showMoreButton, proposalCard, selectedProposalCard, proposalDetailsItem
+@docs proposalListContainer, showMoreButton, proposalCard, selectedProposalCard, proposalDetailsItem, viewProposalsListInCart
 
 
 # Storage Configuration Components
@@ -110,6 +110,7 @@ and are potentially useful in multiple places.
 
 -}
 
+import Cardano.TxIntent exposing (VoteIntent)
 import Html exposing (Html, div, text)
 import Html.Attributes as HA
 import Html.Events exposing (onCheck, onClick)
@@ -1433,6 +1434,22 @@ proposalDetailsItem label content =
             ]
             [ text (label ++ ":") ]
         , content
+        ]
+
+
+{-| Helper function to quickly view proposals that are already in the cart.
+-}
+viewProposalsListInCart : List { proposalTitle : String, voteIntent : VoteIntent } -> Html msg
+viewProposalsListInCart proposalsInCart =
+    div []
+        (List.map viewProposalRow proposalsInCart)
+
+
+viewProposalRow : { proposalTitle : String, voteIntent : VoteIntent } -> Html msg
+viewProposalRow proposal =
+    div []
+        [ text proposal.proposalTitle
+        , text " todo: display one-liner for the vote"
         ]
 
 

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -311,6 +311,7 @@ type Msg
     | SigningPageMsg Page.Signing.Msg
       -- Cart page
     | CartPageMsg Page.Cart.Msg
+    | DeleteVote { voterIdStr : String, actionIdStr : String }
       -- Multisig DRep registration page
     | MultisigPageMsg Page.MultisigRegistration.Msg
       -- PDF page
@@ -667,6 +668,18 @@ update msg model =
                     Page.Cart.update ctx pageMsg cart
             in
             ( { model | cart = updatedCart }, cmds )
+
+        ( DeleteVote { voterIdStr, actionIdStr }, { cart, networkId } ) ->
+            let
+                updatedCart =
+                    Page.Cart.deleteVote voterIdStr actionIdStr cart
+
+                writeCartToDb =
+                    Storage.write { db = model.db, storeName = "app" } Page.Cart.serialize { key = "cart:" ++ networkIdToString networkId } updatedCart
+                        |> ConcurrentTask.map (always Ignore)
+            in
+            ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete } writeCartToDb
+                |> Tuple.mapFirst (\newTaskPool -> { model | taskPool = newTaskPool, cart = updatedCart })
 
         ( MultisigPageMsg pageMsg, { page } ) ->
             case page of
@@ -1392,6 +1405,7 @@ viewContent model =
         CartPage ->
             Page.Cart.view
                 { wrapMsg = CartPageMsg
+                , deleteVote = DeleteVote
                 , signingLink =
                     \tx expectedSigners ->
                         link (RouteSigning { networkId = model.networkId, tx = Just tx, expectedSigners = expectedSigners }) []

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -312,6 +312,7 @@ type Msg
       -- Cart page
     | CartPageMsg Page.Cart.Msg
     | DeleteVote { voterIdStr : String, actionIdStr : String }
+    | ClearCart
       -- Multisig DRep registration page
     | MultisigPageMsg Page.MultisigRegistration.Msg
       -- PDF page
@@ -680,6 +681,18 @@ update msg model =
             in
             ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete } writeCartToDb
                 |> Tuple.mapFirst (\newTaskPool -> { model | taskPool = newTaskPool, cart = updatedCart })
+
+        ( ClearCart, { networkId } ) ->
+            let
+                emptyCart =
+                    Page.Cart.init
+
+                writeCartToDb =
+                    Storage.write { db = model.db, storeName = "app" } Page.Cart.serialize { key = "cart:" ++ networkIdToString networkId } emptyCart
+                        |> ConcurrentTask.map (always Ignore)
+            in
+            ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete } writeCartToDb
+                |> Tuple.mapFirst (\newTaskPool -> { model | taskPool = newTaskPool, cart = emptyCart })
 
         ( MultisigPageMsg pageMsg, { page } ) ->
             case page of
@@ -1407,6 +1420,7 @@ viewContent model =
             Page.Cart.view
                 { wrapMsg = CartPageMsg
                 , deleteVote = DeleteVote
+                , clearCart = ClearCart
                 , signingLink =
                     \tx expectedSigners ->
                         link (RouteSigning { networkId = model.networkId, tx = Just tx, expectedSigners = expectedSigners }) []

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -1379,6 +1379,7 @@ viewContent model =
                 , loadedWallet = loadedWallet
                 , drepId = model.walletDrepId
                 , epoch = RemoteData.toMaybe model.epoch
+                , cart = model.cart
                 , proposals = model.proposals
                 , jsonLdContexts = model.jsonLdContexts
                 , costModels = Maybe.map .costModels model.protocolParams

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -203,6 +203,7 @@ type TaskCompleted
     | GotLastVoter (Maybe Gov.Id)
     | GotLastStorageConfig Page.Preparation.StorageConfig
     | GotProposalMetadataTask String (Result String ProposalMetadata)
+    | GotCart Page.Cart.Model
     | PreparationTaskCompleted Page.Preparation.TaskCompleted
 
 
@@ -223,12 +224,23 @@ initHelper route config =
     let
         ( model, cmd ) =
             handleUrlChange route (initialModel config)
+
+        loadCart =
+            Storage.read { db = config.db, storeName = "app" }
+                Page.Cart.deserialize
+                { key = "cart:" ++ networkIdToString config.networkId }
+                |> ConcurrentTask.map GotCart
+                |> ConcurrentTask.onError (\_ -> ConcurrentTask.succeed Ignore)
+
+        ( updatedTaskPool, tasksCmds ) =
+            ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete } loadCart
     in
-    ( model
+    ( { model | taskPool = updatedTaskPool }
     , Cmd.batch
         [ cmd
         , toWallet (Cip30.encodeRequest Cip30.discoverWallets)
         , Api.defaultApiProvider.loadProtocolParams model.networkId GotProtocolParams
+        , tasksCmds
         ]
     )
 
@@ -481,22 +493,36 @@ update msg model =
 
         ( NetworkChanged newNet, _ ) ->
             let
+                loadCart =
+                    Storage.read { db = model.db, storeName = "app" }
+                        Page.Cart.deserialize
+                        { key = "cart:" ++ networkIdToString newNet }
+                        |> ConcurrentTask.map GotCart
+                        |> ConcurrentTask.onError (\_ -> ConcurrentTask.succeed Ignore)
+
+                ( updatedTaskPool, tasksCmds ) =
+                    ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete } loadCart
+
                 updatedModel =
                     { model
                         | networkId = newNet
                         , networkDropdownIsOpen = False -- Close dropdown after selection
                         , proposals = RemoteData.NotAsked
+                        , cart = Page.Cart.init
+                        , taskPool = updatedTaskPool
                     }
             in
             case model.page of
                 PreparationPage _ ->
                     handleUrlChange (RoutePreparation { networkId = newNet }) updatedModel
+                        |> Cmd.Extra.add tasksCmds
 
                 SigningPage _ ->
                     handleUrlChange (RouteSigning { networkId = newNet, tx = Nothing, expectedSigners = [] }) updatedModel
+                        |> Cmd.Extra.add tasksCmds
 
                 _ ->
-                    ( updatedModel, Cmd.none )
+                    ( updatedModel, tasksCmds )
 
         ( NoMsg, _ ) ->
             ( model, Cmd.none )
@@ -1003,7 +1029,7 @@ handleWalletResponse response model =
                     ( model, Cmd.none )
 
         Cip30.ApiResponse _ _ ->
-            ( { model | errors = "TODO: unhandled CIP30 response yet" :: model.errors }
+            ( { model | errors = "Unhandled CIP30 response yet" :: model.errors }
             , Cmd.none
             )
 
@@ -1086,10 +1112,12 @@ updateModelWithPrepToParentMsg msgToParent model =
                 updatedCart =
                     Page.Cart.addVote voter voteRecord model.cart
 
-                -- TODO: Generate a task to store the updated cart
-                -- TODO: keep the network around when storing? To differentiate Mainnet / Preview
+                writeCartToDb =
+                    Storage.write { db = model.db, storeName = "app" } Page.Cart.serialize { key = "cart:" ++ networkIdToString model.networkId } updatedCart
+                        |> ConcurrentTask.map (always Ignore)
             in
-            ( { model | cart = updatedCart }, Cmd.none )
+            ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete } writeCartToDb
+                |> Tuple.mapFirst (\newTaskPool -> { model | taskPool = newTaskPool, cart = updatedCart })
 
         Just (Page.Preparation.RunTask task) ->
             ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete }
@@ -1161,6 +1189,9 @@ handleCompletedTask response model =
             ( { model | proposals = RemoteData.map (\ps -> Dict.update id updateMetadata ps) model.proposals }
             , Cmd.none
             )
+
+        ( ConcurrentTask.Success (GotCart cart), _ ) ->
+            ( { model | cart = cart }, Cmd.none )
 
         ( ConcurrentTask.Success (PreparationTaskCompleted taskCompleted), PreparationPage pageModel ) ->
             let

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -1038,6 +1038,17 @@ handleWalletResponse response model =
         Cip30.ApiResponse _ (Cip30ApiResponse (Cip30.SubmittedTx txId)) ->
             case model.page of
                 SigningPage pageModel ->
+                    let
+                        emptyCart =
+                            Page.Cart.init
+
+                        writeCartToDb =
+                            Storage.write { db = model.db, storeName = "app" } Page.Cart.serialize { key = "cart:" ++ networkIdToString model.networkId } emptyCart
+                                |> ConcurrentTask.map (always Ignore)
+
+                        ( updatedTaskPool, taskCmds ) =
+                            ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete } writeCartToDb
+                    in
                     ( { model
                         | page = SigningPage <| Page.Signing.recordSubmittedTx txId pageModel
 
@@ -1046,8 +1057,12 @@ handleWalletResponse response model =
                             Maybe.map2 updateWalletUtxosWithTx
                                 (Page.Signing.getTxInfo pageModel)
                                 model.walletUtxos
+
+                        -- Reset the cart
+                        , cart = emptyCart
+                        , taskPool = updatedTaskPool
                       }
-                    , Cmd.none
+                    , taskCmds
                     )
 
                 -- No other page expects to submit a Tx

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -70,6 +70,7 @@ import Html.Events exposing (preventDefaultOn)
 import Http
 import Json.Decode as JD exposing (Decoder, Value)
 import Json.Encode as JE
+import Page.Cart
 import Page.Disclaimer
 import Page.MultisigRegistration
 import Page.Pdf
@@ -182,6 +183,7 @@ type alias Model =
     , networkId : NetworkId
     , ipfsPreconfig : { label : String, description : String }
     , voterPreconfig : List PreconfVoter
+    , cart : Page.Cart.Model
     , errors : List String
     }
 
@@ -190,6 +192,7 @@ type Page
     = LandingPage
     | PreparationPage Page.Preparation.Model
     | SigningPage Page.Signing.Model
+    | CartPage
     | MultisigRegistrationPage Page.MultisigRegistration.Model
     | PdfPage Page.Pdf.Model
     | DisclaimerPage
@@ -263,6 +266,7 @@ initialModel { jsonLdContexts, db, networkId, ipfsPreconfig, voterPreconfig } =
     , networkId = networkId
     , ipfsPreconfig = ipfsPreconfig
     , voterPreconfig = voterPreconfig
+    , cart = Page.Cart.init
     , errors = []
     }
 
@@ -293,6 +297,8 @@ type Msg
     | GotRationaleAsFile Value
       -- Signing page
     | SigningPageMsg Page.Signing.Msg
+      -- Cart page
+    | CartPageMsg Page.Cart.Msg
       -- Multisig DRep registration page
     | MultisigPageMsg Page.MultisigRegistration.Msg
       -- PDF page
@@ -306,6 +312,7 @@ type Route
     = RouteLanding
     | RoutePreparation { networkId : NetworkId }
     | RouteSigning { networkId : NetworkId, expectedSigners : List { keyName : String, keyHash : Bytes CredentialHash }, tx : Maybe Transaction }
+    | RouteCart { networkId : NetworkId }
     | RouteMultisigRegistration
     | RoutePdf
     | RouteDisclaimer
@@ -360,6 +367,9 @@ locationHrefToRoute locationHref =
 
                 [ "page", "preparation" ] ->
                     RoutePreparation { networkId = networkId }
+
+                [ "page", "cart" ] ->
+                    RouteCart { networkId = networkId }
 
                 [ "page", "signing" ] ->
                     RouteSigning
@@ -417,6 +427,12 @@ routeToAppUrl route =
                     , ( "signer", List.map (\{ keyName, keyHash } -> keyName ++ ";" ++ Bytes.toHex keyHash) expectedSigners )
                     ]
             , fragment = Maybe.map (Bytes.toHex << Transaction.serialize) tx
+            }
+
+        RouteCart { networkId } ->
+            { path = [ "page", "cart" ]
+            , queryParameters = Dict.singleton "networkId" [ networkIdToString networkId ]
+            , fragment = Nothing
             }
 
         RouteMultisigRegistration ->
@@ -605,6 +621,27 @@ update msg model =
                 _ ->
                     ( model, Cmd.none )
 
+        ( CartPageMsg pageMsg, { cart } ) ->
+            let
+                loadedWallet =
+                    case ( model.wallet, model.walletUtxos ) of
+                        ( Just wallet, Just utxos ) ->
+                            Just { wallet = wallet, utxos = utxos }
+
+                        _ ->
+                            Nothing
+
+                ctx =
+                    { wrapMsg = CartPageMsg
+                    , costModels = Maybe.map .costModels model.protocolParams
+                    , loadedWallet = loadedWallet
+                    }
+
+                ( updatedCart, cmds ) =
+                    Page.Cart.update ctx pageMsg cart
+            in
+            ( { model | cart = updatedCart }, cmds )
+
         ( MultisigPageMsg pageMsg, { page } ) ->
             case page of
                 MultisigRegistrationPage pageModel ->
@@ -739,7 +776,7 @@ handleUrlChange route model =
             routeToAppUrl route
 
         pushUrlCmd =
-            if routeToAppUrl route == model.appUrl then
+            if appUrl == model.appUrl then
                 Cmd.none
 
             else
@@ -826,6 +863,25 @@ handleUrlChange route model =
                 ( { model
                     | errors = []
                     , page = SigningPage <| Page.Signing.initialModel expectedSigners tx
+                    , appUrl = appUrl
+                  }
+                , pushUrlCmd
+                )
+
+        RouteCart { networkId } ->
+            if networkId /= model.networkId then
+                initHelper route
+                    { jsonLdContexts = model.jsonLdContexts
+                    , db = model.db
+                    , networkId = networkId
+                    , ipfsPreconfig = model.ipfsPreconfig
+                    , voterPreconfig = model.voterPreconfig
+                    }
+
+            else
+                ( { model
+                    | errors = []
+                    , page = CartPage
                     , appUrl = appUrl
                   }
                 , pushUrlCmd
@@ -1025,6 +1081,16 @@ updateModelWithPrepToParentMsg msgToParent model =
             ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete } writeStorageConfigToDb
                 |> Tuple.mapFirst (\newTaskPool -> { model | taskPool = newTaskPool })
 
+        Just (Page.Preparation.AddVoteToCart voter voteRecord) ->
+            let
+                updatedCart =
+                    Page.Cart.addVote voter voteRecord model.cart
+
+                -- TODO: Generate a task to store the updated cart
+                -- TODO: keep the network around when storing? To differentiate Mainnet / Preview
+            in
+            ( { model | cart = updatedCart }, Cmd.none )
+
         Just (Page.Preparation.RunTask task) ->
             ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete }
                 (ConcurrentTask.map PreparationTaskCompleted task)
@@ -1202,6 +1268,10 @@ viewHeader model =
                         _ ->
                             False
               }
+            , { label = "Cart"
+              , link = link <| RouteCart { networkId = model.networkId }
+              , isActive = model.page == CartPage
+              }
             , { label = "PDFs"
               , link = link RoutePdf
               , isActive =
@@ -1287,6 +1357,15 @@ viewContent model =
                 , networkId = model.networkId
                 }
                 signingModel
+
+        CartPage ->
+            Page.Cart.view
+                { wrapMsg = CartPageMsg
+                , signingLink =
+                    \tx expectedSigners ->
+                        link (RouteSigning { networkId = model.networkId, tx = Just tx, expectedSigners = expectedSigners }) []
+                }
+                model.cart
 
         MultisigRegistrationPage pageModel ->
             Page.MultisigRegistration.view

--- a/frontend/src/Page/Cart.elm
+++ b/frontend/src/Page/Cart.elm
@@ -32,13 +32,17 @@ import Natural as N
 -- that are independent from the context.
 
 
+{-| The Cart model has two states, preparing and ready.
+By default, when adding votes to the cart, we will try to prepare
+a transaction and estimate resources usage.
+I think it’s reasonable to do at each vote added to the cart,
+because most voters don’t use Plutus scripts, so it will be almost instant.
+If for any reason, like no wallet connected, we fail to build the vote Tx,
+we stay in the preparing state.
+Otherwise, we are in the ready state.
+-}
 type Model
     = Preparing CartPreparation
-      -- TODO: wondering if it should instead be something like:
-      -- { votersIntents : Dict String CartVoter
-      -- , ready : Maybe CartReady
-      -- }
-      -- with CartReady not containing the unusedIntents field
     | Ready CartReady
 
 
@@ -66,8 +70,7 @@ type alias VoteRecord =
 
 
 type alias CartReady =
-    { unusedIntents : Dict String CartVoter -- keys are bech32 gov IDs
-    , votersIntents : Dict String CartVoter -- keys are bech32 gov IDs
+    { votersIntents : Dict String CartVoter -- keys are bech32 gov IDs
     , maxResources : Resources
     , currentResources : Resources
     , txFinalized : TxFinalized
@@ -127,8 +130,7 @@ update ctx msg model =
                             }
                     in
                     ( Ready
-                        { unusedIntents = Dict.empty
-                        , votersIntents = votersIntents
+                        { votersIntents = votersIntents
                         , maxResources = maxResources
                         , currentResources = txResources
                         , txFinalized = txFinalized
@@ -154,6 +156,7 @@ update ctx msg model =
 
 
 {-| Add a vote to the cart.
+Reset the state to Preparing.
 -}
 addVote : Witness.Voter -> VoteRecord -> Model -> Model
 addVote voter voteRecord model =
@@ -182,8 +185,8 @@ addVote voter voteRecord model =
         Preparing { votersIntents } ->
             Preparing { votersIntents = updateVotersIntents votersIntents, error = Nothing }
 
-        Ready ({ unusedIntents } as ready) ->
-            Ready { ready | unusedIntents = updateVotersIntents unusedIntents }
+        Ready { votersIntents } ->
+            Preparing { votersIntents = updateVotersIntents votersIntents, error = Nothing }
 
 
 
@@ -411,23 +414,10 @@ viewVoteRecord ( actionIdStr, { proposalTitle, voteIntent } ) =
 
 
 viewReadyCart : ViewContext a msg -> CartReady -> Html msg
-viewReadyCart ctx { unusedIntents, votersIntents, maxResources, currentResources, txFinalized } =
+viewReadyCart ctx { votersIntents, maxResources, currentResources, txFinalized } =
     let
-        unusedVotesCount =
-            countAllVotersVotes unusedIntents
-
         countedVotesCount =
             countAllVotersVotes votersIntents
-
-        viewUnusedIntents =
-            if unusedVotesCount == 0 then
-                text ""
-
-            else
-                div [] <|
-                    (Html.h3 [] [ text "Unused votes" ]
-                        :: List.map viewVoterIntents (Dict.toList unusedIntents)
-                    )
 
         viewVotersIntents =
             if countedVotesCount == 0 then
@@ -440,8 +430,7 @@ viewReadyCart ctx { unusedIntents, votersIntents, maxResources, currentResources
                     )
     in
     div []
-        [ viewUnusedIntents
-        , viewResources maxResources currentResources
+        [ viewResources maxResources currentResources
         , viewVotersIntents
 
         -- TODO: add button to go to signing page

--- a/frontend/src/Page/Cart.elm
+++ b/frontend/src/Page/Cart.elm
@@ -570,7 +570,7 @@ viewPreparingCart ctx { votersIntents, error } =
 
 
 viewVoterIntents : ( String, { voter : Witness.Voter, voteRecords : Dict String VoteRecord } ) -> Html msg
-viewVoterIntents ( voterIdStr, { voter, voteRecords } ) =
+viewVoterIntents ( voterIdStr, { voteRecords } ) =
     div []
         -- TODO: improve voter details
         [ Html.h4 [] [ text <| "Voter: " ++ voterIdStr ]
@@ -581,7 +581,7 @@ viewVoterIntents ( voterIdStr, { voter, voteRecords } ) =
 viewVoteRecord : ( String, VoteRecord ) -> Html msg
 viewVoteRecord ( actionIdStr, { proposalTitle, voteIntent } ) =
     let
-        { actionId, vote, rationale } =
+        { vote, rationale } =
             voteIntent
 
         viewRationale =
@@ -597,7 +597,7 @@ viewVoteRecord ( actionIdStr, { proposalTitle, voteIntent } ) =
         , text " | "
         , text proposalTitle
         , text " | action ID: "
-        , text <| Gov.actionIdToString actionId
+        , text actionIdStr
         , text " | rationale: "
         , text viewRationale
         ]

--- a/frontend/src/Page/Cart.elm
+++ b/frontend/src/Page/Cart.elm
@@ -601,6 +601,7 @@ type alias ViewContext a msg =
     { a
         | wrapMsg : Msg -> msg
         , deleteVote : { voterIdStr : String, actionIdStr : String } -> msg
+        , clearCart : msg
         , signingLink : Transaction -> List { keyName : String, keyHash : Bytes CredentialHash } -> List (Html msg) -> Html msg
     }
 
@@ -618,7 +619,8 @@ view ctx model =
 viewPreparingCart : ViewContext a msg -> CartPreparation -> Html msg
 viewPreparingCart ctx { votersIntents, error } =
     div []
-        [ div [] <|
+        [ Html.button [ HE.onClick ctx.clearCart ] [ text "Clear Cart" ]
+        , div [] <|
             List.map (viewVoterIntents ctx) (Dict.toList votersIntents)
         , Html.button [ HE.onClick <| ctx.wrapMsg BuildTx ] [ text "build Tx" ]
         , viewError error
@@ -681,6 +683,7 @@ viewReadyCart ctx { votersIntents, maxResources, currentResources, txFinalized }
     in
     div []
         [ viewResources maxResources currentResources
+        , Html.button [ HE.onClick ctx.clearCart ] [ text "Clear Cart" ]
         , viewVotersIntents
         , viewSigningButton ctx txFinalized
         ]

--- a/frontend/src/Page/Cart.elm
+++ b/frontend/src/Page/Cart.elm
@@ -1,11 +1,11 @@
-module Page.Cart exposing (Model, Msg, UpdateContext, ViewContext, VoteRecord, addVote, init, update, view)
+module Page.Cart exposing (Model, Msg, UpdateContext, ViewContext, VoteRecord, addVote, deserialize, init, serialize, update, view)
 
 import Bytes.Comparable as Bytes exposing (Bytes)
 import Cardano.Address as Address exposing (Address, CredentialHash)
 import Cardano.Cip30 as Cip30
 import Cardano.CoinSelection as CoinSelection
 import Cardano.Gov as Gov exposing (ActionId, Anchor, CostModels, Id(..))
-import Cardano.Script as Script exposing (ScriptCbor)
+import Cardano.Script as Script
 import Cardano.Transaction as Transaction exposing (Transaction)
 import Cardano.TxIntent as TxIntent exposing (Fee(..), TxFinalized, TxIntent, VoteIntent)
 import Cardano.Uplc as Uplc
@@ -14,22 +14,13 @@ import Cardano.Utxo as Utxo exposing (Output)
 import Cardano.Witness as Witness exposing (Voter(..))
 import Dict exposing (Dict)
 import Dict.Any
-import Helper exposing (viewError, viewVoterCard)
+import Helper exposing (viewError)
 import Html exposing (Html, div, text)
 import Html.Attributes as HA
 import Html.Events as HE
 import Json.Decode as JD
 import Json.Encode as JE
 import Natural as N
-
-
-
--- TODO: figure out how to locally store cart in browser db.
--- The hard part is storing the script witness for native/plutus scripts.
--- For the script, we can keep a separate store of script per hash.
--- For the redeemer function (TxContext -> Data) we can store just the data
--- applied to an empty TxContext, so will only work for redeemers
--- that are independent from the context.
 
 
 {-| The Cart model has two states, preparing and ready.
@@ -193,17 +184,129 @@ addVote voter voteRecord model =
 -- Serialization
 
 
-serializeCredentialWitness : Witness.Credential -> ( JE.Value, Maybe ( Bytes CredentialHash, Bytes ScriptCbor ) )
+serialize : Model -> JE.Value
+serialize cart =
+    case cart of
+        Preparing { votersIntents } ->
+            serializeVotersIntents votersIntents
+
+        Ready { votersIntents } ->
+            serializeVotersIntents votersIntents
+
+
+{-| Serialization of all voters intents into a single JSON object.
+
+There are many trade-offs between serializing all intents into a single object
+or doing multiple objects such as one per voter or one per proposal.
+
+The problem with one per voter, is that when reloading the app,
+we cannot know in advance which voters to load, unless we have an api
+to retrieve all items of a given store.
+(which might be a good idea, but for now we only have read per-key in the store)
+
+The problem with one per proposal, is that we have to duplicate the voter witness
+for each and every proposal.
+It might get error-prone as we essentially duplicate information
+that is not supposed to be duplicated.
+
+The problem with one single object for the whole cart,
+is that we have the serialize the whole cart every time we update it.
+And potentially riskier if something goes wrong and remove the whole cart.
+
+There are counter-measures of course for each approach,
+but for the sake of simplicity, let’s start with one single JSON object.
+
+-}
+serializeVotersIntents : Dict String CartVoter -> JE.Value
+serializeVotersIntents votersIntents =
+    JE.dict identity serializeCartVoter votersIntents
+
+
+serializeCartVoter : CartVoter -> JE.Value
+serializeCartVoter { voter, voteRecords } =
+    JE.object
+        [ ( "voter", serializeVoter voter )
+        , ( "voteRecords", JE.dict identity serializeVoteRecord voteRecords )
+        ]
+
+
+serializeVoter : Witness.Voter -> JE.Value
+serializeVoter voter =
+    case voter of
+        WithCommitteeHotCred cred ->
+            JE.object
+                [ ( "type", JE.string "withCommitteeHotCred" )
+                , ( "cred", serializeCredentialWitness cred )
+                ]
+
+        WithDrepCred cred ->
+            JE.object
+                [ ( "type", JE.string "withDrepCred" )
+                , ( "cred", serializeCredentialWitness cred )
+                ]
+
+        WithPoolCred credHash ->
+            JE.object
+                [ ( "type", JE.string "withPoolCred" )
+                , ( "credHash", Bytes.jsonEncode credHash )
+                ]
+
+
+serializeVoteRecord : VoteRecord -> JE.Value
+serializeVoteRecord { proposalTitle, voteIntent } =
+    JE.object
+        [ ( "proposalTitle", JE.string proposalTitle )
+        , ( "voteIntent", serializeVoteIntent voteIntent )
+        ]
+
+
+serializeVoteIntent : VoteIntent -> JE.Value
+serializeVoteIntent { actionId, vote, rationale } =
+    JE.object
+        [ ( "actionId", serializeActionId actionId )
+        , ( "vote", serializeVote vote )
+        , ( "rationale", Maybe.map serializeAnchor rationale |> Maybe.withDefault JE.null )
+        ]
+
+
+serializeActionId : ActionId -> JE.Value
+serializeActionId { transactionId, govActionIndex } =
+    JE.object
+        [ ( "transactionId", Bytes.jsonEncode transactionId )
+        , ( "govActionIndex", JE.int govActionIndex )
+        ]
+
+
+serializeVote : Gov.Vote -> JE.Value
+serializeVote vote =
+    case vote of
+        Gov.VoteNo ->
+            JE.int 0
+
+        Gov.VoteYes ->
+            JE.int 1
+
+        Gov.VoteAbstain ->
+            JE.int 2
+
+
+serializeAnchor : Anchor -> JE.Value
+serializeAnchor { url, dataHash } =
+    JE.object
+        [ ( "url", JE.string url )
+        , ( "dataHash", Bytes.jsonEncode dataHash )
+        ]
+
+
+serializeCredentialWitness : Witness.Credential -> JE.Value
 serializeCredentialWitness cred =
     -- type: key | nativeScriptByValue | nativeScriptByRef | plutusScriptByValue | plutusScriptByRef
     case cred of
         Witness.WithKey keyHash ->
-            ( JE.object
+            JE.object
                 [ ( "type", JE.string "key" )
                 , ( "keyHash", Bytes.jsonEncode keyHash )
                 ]
-            , Nothing
-            )
 
         Witness.WithScript scriptHash scriptWitness ->
             case scriptWitness of
@@ -211,24 +314,20 @@ serializeCredentialWitness cred =
                     case script of
                         -- For NativeScript, we just serialize the script inline
                         Witness.ByValue nativeScript ->
-                            ( JE.object
+                            JE.object
                                 [ ( "type", JE.string "nativeScriptByValue" )
                                 , ( "scriptHash", Bytes.jsonEncode scriptHash )
                                 , ( "script", Script.jsonEncodeNativeScript nativeScript )
                                 , ( "expectedSigners", JE.list Bytes.jsonEncode expectedSigners )
                                 ]
-                            , Nothing
-                            )
 
                         Witness.ByReference ref ->
-                            ( JE.object
+                            JE.object
                                 [ ( "type", JE.string "nativeScriptByRef" )
                                 , ( "scriptHash", Bytes.jsonEncode scriptHash )
                                 , ( "ref", Utils.jsonEncodeCbor <| Utxo.encodeOutputReference ref )
                                 , ( "expectedSigners", JE.list Bytes.jsonEncode expectedSigners )
                                 ]
-                            , Nothing
-                            )
 
                 Witness.Plutus _ ->
                     Debug.todo "Handle serialization of Plutus witnesses"
@@ -236,6 +335,46 @@ serializeCredentialWitness cred =
 
 
 -- Deserialization
+
+
+deserialize : JD.Decoder Model
+deserialize =
+    JD.map (\intents -> Preparing { votersIntents = intents, error = Nothing }) deserializeVotersIntents
+
+
+deserializeVotersIntents : JD.Decoder (Dict String CartVoter)
+deserializeVotersIntents =
+    JD.dict deserializeCartVoter
+
+
+deserializeCartVoter : JD.Decoder CartVoter
+deserializeCartVoter =
+    JD.map2 CartVoter
+        (JD.field "voter" deserializeVoter)
+        (JD.field "voteRecords" <| JD.dict deserializeVoteRecord)
+
+
+deserializeVoter : JD.Decoder Voter
+deserializeVoter =
+    JD.field "type" JD.string
+        |> JD.andThen
+            (\voterType ->
+                case voterType of
+                    "withCommitteeHotCred" ->
+                        JD.field "cred" deserializeCredentialWitness
+                            |> JD.map WithCommitteeHotCred
+
+                    "withDrepCred" ->
+                        JD.field "cred" deserializeCredentialWitness
+                            |> JD.map WithDrepCred
+
+                    "withPoolCred" ->
+                        JD.field "credHash" Bytes.jsonDecoder
+                            |> JD.map WithPoolCred
+
+                    _ ->
+                        JD.fail <| "Unknown voter type: " ++ voterType
+            )
 
 
 deserializeCredentialWitness : JD.Decoder Witness.Credential
@@ -280,6 +419,55 @@ deserializeCredentialWitness =
                         -- similar to the serialization logic.
                         JD.fail ("Unsupported credential witness type for deserialization: " ++ other)
             )
+
+
+deserializeVoteRecord : JD.Decoder VoteRecord
+deserializeVoteRecord =
+    JD.map2 VoteRecord
+        (JD.field "proposalTitle" JD.string)
+        (JD.field "voteIntent" deserializeVoteIntent)
+
+
+deserializeVoteIntent : JD.Decoder VoteIntent
+deserializeVoteIntent =
+    JD.map3 VoteIntent
+        (JD.field "actionId" deserializeActionId)
+        (JD.field "vote" deserializeVote)
+        (JD.field "rationale" <| JD.maybe deserializeAnchor)
+
+
+deserializeActionId : JD.Decoder ActionId
+deserializeActionId =
+    JD.map2 ActionId
+        (JD.field "transactionId" Bytes.jsonDecoder)
+        (JD.field "govActionIndex" JD.int)
+
+
+deserializeVote : JD.Decoder Gov.Vote
+deserializeVote =
+    JD.int
+        |> JD.andThen
+            (\vote ->
+                case vote of
+                    0 ->
+                        JD.succeed Gov.VoteNo
+
+                    1 ->
+                        JD.succeed Gov.VoteYes
+
+                    2 ->
+                        JD.succeed Gov.VoteAbstain
+
+                    _ ->
+                        JD.fail "Invalid vote value"
+            )
+
+
+deserializeAnchor : JD.Decoder Anchor
+deserializeAnchor =
+    JD.map2 Anchor
+        (JD.field "url" JD.string)
+        (JD.field "dataHash" Bytes.jsonDecoder)
 
 
 
@@ -408,6 +596,8 @@ viewVoteRecord ( actionIdStr, { proposalTitle, voteIntent } ) =
         [ text <| Debug.toString vote
         , text " | "
         , text proposalTitle
+        , text " | action ID: "
+        , text <| Gov.actionIdToString actionId
         , text " | rationale: "
         , text viewRationale
         ]
@@ -432,8 +622,6 @@ viewReadyCart ctx { votersIntents, maxResources, currentResources, txFinalized }
     div []
         [ viewResources maxResources currentResources
         , viewVotersIntents
-
-        -- TODO: add button to go to signing page
         , viewSigningButton ctx txFinalized
         ]
 

--- a/frontend/src/Page/Cart.elm
+++ b/frontend/src/Page/Cart.elm
@@ -1,4 +1,4 @@
-module Page.Cart exposing (Model, Msg, UpdateContext, ViewContext, VoteRecord, addVote, deleteVote, deserialize, init, serialize, update, view)
+module Page.Cart exposing (Model, Msg, UpdateContext, ViewContext, VoteRecord, addVote, contains, deleteVote, deserialize, get, init, serialize, update, view)
 
 import Bytes.Comparable as Bytes exposing (Bytes)
 import Cardano.Address as Address exposing (Address, CredentialHash)
@@ -73,6 +73,33 @@ type alias Resources =
     , steps : Int
     , mem : Int
     }
+
+
+{-| Check if a given proposal is present in the cart.
+-}
+contains : String -> ActionId -> Model -> Bool
+contains voterId actionId model =
+    get voterId actionId model
+        |> Maybe.map (\_ -> True)
+        |> Maybe.withDefault False
+
+
+{-| Try to retrieve a vote from the cart.
+-}
+get : String -> ActionId -> Model -> Maybe VoteRecord
+get voterId actionId model =
+    let
+        actionIdStr =
+            Gov.idToBech32 <| GovActionId actionId
+    in
+    case model of
+        Preparing { votersIntents } ->
+            Dict.get voterId votersIntents
+                |> Maybe.andThen (\{ voteRecords } -> Dict.get actionIdStr voteRecords)
+
+        Ready { votersIntents } ->
+            Dict.get voterId votersIntents
+                |> Maybe.andThen (\{ voteRecords } -> Dict.get actionIdStr voteRecords)
 
 
 

--- a/frontend/src/Page/Cart.elm
+++ b/frontend/src/Page/Cart.elm
@@ -1,0 +1,501 @@
+module Page.Cart exposing (Model, Msg, UpdateContext, ViewContext, VoteRecord, addVote, init, update, view)
+
+import Bytes.Comparable as Bytes exposing (Bytes)
+import Cardano.Address as Address exposing (Address, CredentialHash)
+import Cardano.Cip30 as Cip30
+import Cardano.CoinSelection as CoinSelection
+import Cardano.Gov as Gov exposing (ActionId, Anchor, CostModels, Id(..))
+import Cardano.Script as Script exposing (ScriptCbor)
+import Cardano.Transaction as Transaction exposing (Transaction)
+import Cardano.TxIntent as TxIntent exposing (Fee(..), TxFinalized, TxIntent, VoteIntent)
+import Cardano.Uplc as Uplc
+import Cardano.Utils as Utils
+import Cardano.Utxo as Utxo exposing (Output)
+import Cardano.Witness as Witness exposing (Voter(..))
+import Dict exposing (Dict)
+import Dict.Any
+import Helper exposing (viewError, viewVoterCard)
+import Html exposing (Html, div, text)
+import Html.Attributes as HA
+import Html.Events as HE
+import Json.Decode as JD
+import Json.Encode as JE
+import Natural as N
+
+
+
+-- TODO: figure out how to locally store cart in browser db.
+-- The hard part is storing the script witness for native/plutus scripts.
+-- For the script, we can keep a separate store of script per hash.
+-- For the redeemer function (TxContext -> Data) we can store just the data
+-- applied to an empty TxContext, so will only work for redeemers
+-- that are independent from the context.
+
+
+type Model
+    = Preparing CartPreparation
+      -- TODO: wondering if it should instead be something like:
+      -- { votersIntents : Dict String CartVoter
+      -- , ready : Maybe CartReady
+      -- }
+      -- with CartReady not containing the unusedIntents field
+    | Ready CartReady
+
+
+init : Model
+init =
+    Preparing { votersIntents = Dict.empty, error = Nothing }
+
+
+type alias CartPreparation =
+    { votersIntents : Dict String CartVoter -- keys are bech32 gov IDs
+    , error : Maybe String
+    }
+
+
+type alias CartVoter =
+    { voter : Witness.Voter
+    , voteRecords : Dict String VoteRecord -- keys are bech32 gov IDs (of the action ID)
+    }
+
+
+type alias VoteRecord =
+    { proposalTitle : String
+    , voteIntent : VoteIntent
+    }
+
+
+type alias CartReady =
+    { unusedIntents : Dict String CartVoter -- keys are bech32 gov IDs
+    , votersIntents : Dict String CartVoter -- keys are bech32 gov IDs
+    , maxResources : Resources
+    , currentResources : Resources
+    , txFinalized : TxFinalized
+    }
+
+
+type alias Resources =
+    { txSize : Int
+    , steps : Int
+    , mem : Int
+    }
+
+
+
+-- UPDATE ############################################################
+
+
+type Msg
+    = BuildTx
+
+
+type alias UpdateContext a msg =
+    { a
+        | wrapMsg : Msg -> msg
+        , costModels : Maybe CostModels
+        , loadedWallet : Maybe { wallet : Cip30.Wallet, utxos : Utxo.RefDict Output }
+    }
+
+
+update : UpdateContext a msg -> Msg -> Model -> ( Model, Cmd msg )
+update ctx msg model =
+    case ( ( ctx.loadedWallet, ctx.costModels ), msg, model ) of
+        ( ( Just { wallet, utxos }, Just costModels ), BuildTx, Preparing ({ votersIntents } as cartPrep) ) ->
+            let
+                walletAddress =
+                    Cip30.walletChangeAddress wallet
+            in
+            case buildTx costModels utxos walletAddress votersIntents of
+                Ok ({ tx } as txFinalized) ->
+                    let
+                        txSize =
+                            Bytes.width <| Transaction.serialize tx
+
+                        { totalSteps, totalMem } =
+                            Transaction.computeTotalExecUnits tx
+
+                        txResources =
+                            { txSize = txSize
+                            , steps = N.toInt totalSteps
+                            , mem = N.toInt totalMem
+                            }
+
+                        maxResources =
+                            { txSize = Gov.defaultMaxTxSize
+                            , steps = Gov.defaultMaxTxExUnits.steps
+                            , mem = Gov.defaultMaxTxExUnits.mem
+                            }
+                    in
+                    ( Ready
+                        { unusedIntents = Dict.empty
+                        , votersIntents = votersIntents
+                        , maxResources = maxResources
+                        , currentResources = txResources
+                        , txFinalized = txFinalized
+                        }
+                    , Cmd.none
+                    )
+
+                Err err ->
+                    ( Preparing { cartPrep | error = Just err }, Cmd.none )
+
+        ( ( _, Nothing ), BuildTx, Preparing cartPrep ) ->
+            ( Preparing { cartPrep | error = Just "We failed to load the cost models, maybe try to refresh." }, Cmd.none )
+
+        ( ( Nothing, _ ), BuildTx, Preparing cartPrep ) ->
+            ( Preparing { cartPrep | error = Just "Please connect a wallet to build the transaction" }, Cmd.none )
+
+        ( _, BuildTx, _ ) ->
+            ( model, Cmd.none )
+
+
+
+-- Add a vote
+
+
+{-| Add a vote to the cart.
+-}
+addVote : Witness.Voter -> VoteRecord -> Model -> Model
+addVote voter voteRecord model =
+    let
+        voterIdStr =
+            Witness.toVoter voter
+                |> Gov.voterToId
+                |> Gov.idToBech32
+
+        actionIdStr =
+            Gov.idToBech32 <| GovActionId voteRecord.voteIntent.actionId
+
+        updateVotersIntents : Dict String CartVoter -> Dict String CartVoter
+        updateVotersIntents =
+            Dict.update voterIdStr
+                (\maybeCartVoter ->
+                    case maybeCartVoter of
+                        Nothing ->
+                            Just <| CartVoter voter <| Dict.singleton actionIdStr voteRecord
+
+                        Just { voteRecords } ->
+                            Just <| CartVoter voter <| Dict.insert actionIdStr voteRecord voteRecords
+                )
+    in
+    case model of
+        Preparing { votersIntents } ->
+            Preparing { votersIntents = updateVotersIntents votersIntents, error = Nothing }
+
+        Ready ({ unusedIntents } as ready) ->
+            Ready { ready | unusedIntents = updateVotersIntents unusedIntents }
+
+
+
+-- Serialization
+
+
+serializeCredentialWitness : Witness.Credential -> ( JE.Value, Maybe ( Bytes CredentialHash, Bytes ScriptCbor ) )
+serializeCredentialWitness cred =
+    -- type: key | nativeScriptByValue | nativeScriptByRef | plutusScriptByValue | plutusScriptByRef
+    case cred of
+        Witness.WithKey keyHash ->
+            ( JE.object
+                [ ( "type", JE.string "key" )
+                , ( "keyHash", Bytes.jsonEncode keyHash )
+                ]
+            , Nothing
+            )
+
+        Witness.WithScript scriptHash scriptWitness ->
+            case scriptWitness of
+                Witness.Native { script, expectedSigners } ->
+                    case script of
+                        -- For NativeScript, we just serialize the script inline
+                        Witness.ByValue nativeScript ->
+                            ( JE.object
+                                [ ( "type", JE.string "nativeScriptByValue" )
+                                , ( "scriptHash", Bytes.jsonEncode scriptHash )
+                                , ( "script", Script.jsonEncodeNativeScript nativeScript )
+                                , ( "expectedSigners", JE.list Bytes.jsonEncode expectedSigners )
+                                ]
+                            , Nothing
+                            )
+
+                        Witness.ByReference ref ->
+                            ( JE.object
+                                [ ( "type", JE.string "nativeScriptByRef" )
+                                , ( "scriptHash", Bytes.jsonEncode scriptHash )
+                                , ( "ref", Utils.jsonEncodeCbor <| Utxo.encodeOutputReference ref )
+                                , ( "expectedSigners", JE.list Bytes.jsonEncode expectedSigners )
+                                ]
+                            , Nothing
+                            )
+
+                Witness.Plutus _ ->
+                    Debug.todo "Handle serialization of Plutus witnesses"
+
+
+
+-- Deserialization
+
+
+deserializeCredentialWitness : JD.Decoder Witness.Credential
+deserializeCredentialWitness =
+    JD.field "type" JD.string
+        |> JD.andThen
+            (\witnessType ->
+                case witnessType of
+                    "key" ->
+                        JD.map Witness.WithKey (JD.field "keyHash" Bytes.jsonDecoder)
+
+                    "nativeScriptByValue" ->
+                        JD.map3
+                            (\scriptHash script signers ->
+                                Witness.WithScript scriptHash
+                                    (Witness.Native
+                                        { script = Witness.ByValue script
+                                        , expectedSigners = signers
+                                        }
+                                    )
+                            )
+                            (JD.field "scriptHash" Bytes.jsonDecoder)
+                            (JD.field "script" Script.jsonDecodeNativeScript)
+                            (JD.field "expectedSigners" (JD.list Bytes.jsonDecoder))
+
+                    "nativeScriptByRef" ->
+                        JD.map3
+                            (\scriptHash ref signers ->
+                                Witness.WithScript scriptHash
+                                    (Witness.Native
+                                        { script = Witness.ByReference ref
+                                        , expectedSigners = signers
+                                        }
+                                    )
+                            )
+                            (JD.field "scriptHash" Bytes.jsonDecoder)
+                            (JD.field "ref" <| Utils.jsonDecodeCbor Utxo.decodeOutputReference)
+                            (JD.field "expectedSigners" (JD.list Bytes.jsonDecoder))
+
+                    other ->
+                        -- Deserialization for Plutus scripts is not yet implemented,
+                        -- similar to the serialization logic.
+                        JD.fail ("Unsupported credential witness type for deserialization: " ++ other)
+            )
+
+
+
+-- Tx Building
+
+
+buildTx : CostModels -> Utxo.RefDict Output -> Address -> Dict String CartVoter -> Result String TxFinalized
+buildTx costModels localStateUtxos walletAddress votersIntents =
+    let
+        -- Use any address (enterprise / full) with the same payment cred
+        -- as the one from the default wallet address to pay the fee
+        walletOutputs =
+            Dict.Any.values localStateUtxos
+
+        potentialFeeSources =
+            case Address.extractPubKeyHash walletAddress of
+                Just paymentCred ->
+                    walletOutputs
+                        |> List.map (\output -> output.address)
+                        |> List.filter (\addr -> Address.extractPubKeyHash addr == Just paymentCred)
+
+                Nothing ->
+                    []
+
+        -- Helper function to gather free Ada for a given address
+        -- Convert Natural amounts to Int (1 = 1 ada) for easy comparison
+        freeAdaForAddress address =
+            let
+                freeAda output =
+                    if output.address == address then
+                        Utxo.freeAda output
+
+                    else
+                        N.zero
+            in
+            walletOutputs
+                |> List.foldl (\output sum -> N.add sum <| freeAda output) N.zero
+                -- divide by 1000000 to get ada amount from lovelace amount
+                |> (\n -> n |> N.divBy (N.fromSafeInt 1000000))
+                |> Maybe.withDefault N.zero
+                |> N.toInt
+
+        -- Pick the one with most free Ada as the payment source
+        feeSource =
+            List.sortBy freeAdaForAddress potentialFeeSources
+                |> List.reverse
+                |> List.head
+                |> Maybe.withDefault walletAddress
+
+        allVoteIntents : List TxIntent
+        allVoteIntents =
+            Dict.values votersIntents
+                |> List.map
+                    (\{ voter, voteRecords } ->
+                        TxIntent.Vote voter <| List.map .voteIntent <| Dict.values voteRecords
+                    )
+    in
+    allVoteIntents
+        |> TxIntent.finalizeAdvanced
+            { govState = TxIntent.emptyGovernanceState
+            , localStateUtxos = localStateUtxos
+            , coinSelectionAlgo = CoinSelection.largestFirst
+            , evalScriptsCosts = Uplc.evalScriptsCosts Uplc.defaultVmConfig
+            , costModels = costModels
+            }
+            (AutoFee { paymentSource = feeSource })
+            []
+        |> Result.mapError TxIntent.errorToString
+
+
+
+-- VIEW ##############################################################
+
+
+type alias ViewContext a msg =
+    { a
+        | wrapMsg : Msg -> msg
+        , signingLink : Transaction -> List { keyName : String, keyHash : Bytes CredentialHash } -> List (Html msg) -> Html msg
+    }
+
+
+view : ViewContext a msg -> Model -> Html msg
+view ctx model =
+    case model of
+        Preparing cartPreparation ->
+            viewPreparingCart ctx cartPreparation
+
+        Ready cartReady ->
+            viewReadyCart ctx cartReady
+
+
+viewPreparingCart : ViewContext a msg -> CartPreparation -> Html msg
+viewPreparingCart ctx { votersIntents, error } =
+    div []
+        [ div [] <|
+            List.map viewVoterIntents (Dict.toList votersIntents)
+        , Html.button [ HE.onClick <| ctx.wrapMsg BuildTx ] [ text "build Tx" ]
+        , viewError error
+        ]
+
+
+viewVoterIntents : ( String, { voter : Witness.Voter, voteRecords : Dict String VoteRecord } ) -> Html msg
+viewVoterIntents ( voterIdStr, { voter, voteRecords } ) =
+    div []
+        -- TODO: improve voter details
+        [ Html.h4 [] [ text <| "Voter: " ++ voterIdStr ]
+        , div [] <| List.map viewVoteRecord <| Dict.toList voteRecords
+        ]
+
+
+viewVoteRecord : ( String, VoteRecord ) -> Html msg
+viewVoteRecord ( actionIdStr, { proposalTitle, voteIntent } ) =
+    let
+        { actionId, vote, rationale } =
+            voteIntent
+
+        viewRationale =
+            case rationale of
+                Nothing ->
+                    "none"
+
+                Just { url } ->
+                    url
+    in
+    Html.p []
+        [ text <| Debug.toString vote
+        , text " | "
+        , text proposalTitle
+        , text " | rationale: "
+        , text viewRationale
+        ]
+
+
+viewReadyCart : ViewContext a msg -> CartReady -> Html msg
+viewReadyCart ctx { unusedIntents, votersIntents, maxResources, currentResources, txFinalized } =
+    let
+        unusedVotesCount =
+            countAllVotersVotes unusedIntents
+
+        countedVotesCount =
+            countAllVotersVotes votersIntents
+
+        viewUnusedIntents =
+            if unusedVotesCount == 0 then
+                text ""
+
+            else
+                div [] <|
+                    (Html.h3 [] [ text "Unused votes" ]
+                        :: List.map viewVoterIntents (Dict.toList unusedIntents)
+                    )
+
+        viewVotersIntents =
+            if countedVotesCount == 0 then
+                text "The generated Tx doesn’t contain any vote."
+
+            else
+                div [] <|
+                    (Html.h3 [] [ text "Votes ready for submission" ]
+                        :: List.map viewVoterIntents (Dict.toList votersIntents)
+                    )
+    in
+    div []
+        [ viewUnusedIntents
+        , viewResources maxResources currentResources
+        , viewVotersIntents
+
+        -- TODO: add button to go to signing page
+        , viewSigningButton ctx txFinalized
+        ]
+
+
+countAllVotersVotes : Dict String CartVoter -> Int
+countAllVotersVotes votes =
+    Dict.foldl (\_ cartVoter acc -> acc + Dict.size cartVoter.voteRecords) 0 votes
+
+
+viewResources : Resources -> Resources -> Html msg
+viewResources maxResources currentResources =
+    let
+        usagePercent used max =
+            ceiling (100 * toFloat used / toFloat max)
+
+        sizeUsage =
+            usagePercent currentResources.txSize maxResources.txSize
+
+        stepsUsage =
+            usagePercent currentResources.steps maxResources.steps
+
+        memUsage =
+            usagePercent currentResources.mem maxResources.mem
+
+        overallUsage =
+            max sizeUsage (max stepsUsage memUsage)
+    in
+    div []
+        [ Html.h3 [] [ text "Resource usage:" ]
+        , Html.progress [ HA.max "100", HA.value (String.fromInt overallUsage) ] []
+        , text <| " " ++ String.fromInt overallUsage ++ " %"
+        ]
+
+
+viewSigningButton : ViewContext a msg -> TxFinalized -> Html msg
+viewSigningButton ctx { tx, expectedSignatures } =
+    let
+        keyNames : Dict String String
+        keyNames =
+            -- Debug.todo ""
+            Dict.empty
+    in
+    ctx.signingLink tx
+        (expectedSignatures
+            |> List.map
+                (\keyHash ->
+                    { keyHash = keyHash
+                    , keyName =
+                        Dict.get (Bytes.toHex keyHash) keyNames
+                            |> Maybe.withDefault "Key hash"
+                    }
+                )
+        )
+        [ Helper.signingButton "Go to Signing Page" ]

--- a/frontend/src/Page/Cart.elm
+++ b/frontend/src/Page/Cart.elm
@@ -1,4 +1,4 @@
-module Page.Cart exposing (Model, Msg, UpdateContext, ViewContext, VoteRecord, addVote, deserialize, init, serialize, update, view)
+module Page.Cart exposing (Model, Msg, UpdateContext, ViewContext, VoteRecord, addVote, deleteVote, deserialize, init, serialize, update, view)
 
 import Bytes.Comparable as Bytes exposing (Bytes)
 import Cardano.Address as Address exposing (Address, CredentialHash)
@@ -143,7 +143,7 @@ update ctx msg model =
 
 
 
--- Add a vote
+-- Add / Delete a vote
 
 
 {-| Add a vote to the cart.
@@ -178,6 +178,34 @@ addVote voter voteRecord model =
 
         Ready { votersIntents } ->
             Preparing { votersIntents = updateVotersIntents votersIntents, error = Nothing }
+
+
+{-| Delete a vote from the cart.
+Reset the state to Preparing.
+-}
+deleteVote : String -> String -> Model -> Model
+deleteVote voterIdStr actionIdStr model =
+    let
+        removeVoteFromCart intents =
+            Dict.update voterIdStr (Maybe.andThen removeActionId) intents
+
+        removeActionId : CartVoter -> Maybe CartVoter
+        removeActionId { voter, voteRecords } =
+            Dict.remove actionIdStr voteRecords
+                |> (\newDict ->
+                        if Dict.isEmpty newDict then
+                            Nothing
+
+                        else
+                            Just { voter = voter, voteRecords = newDict }
+                   )
+    in
+    case model of
+        Preparing { votersIntents } ->
+            Preparing { votersIntents = removeVoteFromCart votersIntents, error = Nothing }
+
+        Ready { votersIntents } ->
+            Preparing { votersIntents = removeVoteFromCart votersIntents, error = Nothing }
 
 
 
@@ -545,6 +573,7 @@ buildTx costModels localStateUtxos walletAddress votersIntents =
 type alias ViewContext a msg =
     { a
         | wrapMsg : Msg -> msg
+        , deleteVote : { voterIdStr : String, actionIdStr : String } -> msg
         , signingLink : Transaction -> List { keyName : String, keyHash : Bytes CredentialHash } -> List (Html msg) -> Html msg
     }
 
@@ -563,23 +592,23 @@ viewPreparingCart : ViewContext a msg -> CartPreparation -> Html msg
 viewPreparingCart ctx { votersIntents, error } =
     div []
         [ div [] <|
-            List.map viewVoterIntents (Dict.toList votersIntents)
+            List.map (viewVoterIntents ctx) (Dict.toList votersIntents)
         , Html.button [ HE.onClick <| ctx.wrapMsg BuildTx ] [ text "build Tx" ]
         , viewError error
         ]
 
 
-viewVoterIntents : ( String, { voter : Witness.Voter, voteRecords : Dict String VoteRecord } ) -> Html msg
-viewVoterIntents ( voterIdStr, { voteRecords } ) =
+viewVoterIntents : ViewContext a msg -> ( String, { voter : Witness.Voter, voteRecords : Dict String VoteRecord } ) -> Html msg
+viewVoterIntents ctx ( voterIdStr, { voteRecords } ) =
     div []
         -- TODO: improve voter details
         [ Html.h4 [] [ text <| "Voter: " ++ voterIdStr ]
-        , div [] <| List.map viewVoteRecord <| Dict.toList voteRecords
+        , div [] <| List.map (viewVoteRecord ctx voterIdStr) <| Dict.toList voteRecords
         ]
 
 
-viewVoteRecord : ( String, VoteRecord ) -> Html msg
-viewVoteRecord ( actionIdStr, { proposalTitle, voteIntent } ) =
+viewVoteRecord : ViewContext a msg -> String -> ( String, VoteRecord ) -> Html msg
+viewVoteRecord ctx voterIdStr ( actionIdStr, { proposalTitle, voteIntent } ) =
     let
         { vote, rationale } =
             voteIntent
@@ -600,6 +629,10 @@ viewVoteRecord ( actionIdStr, { proposalTitle, voteIntent } ) =
         , text actionIdStr
         , text " | rationale: "
         , text viewRationale
+        , text " "
+        , Html.button
+            [ HE.onClick <| ctx.deleteVote { voterIdStr = voterIdStr, actionIdStr = actionIdStr } ]
+            [ text "🗑" ]
         ]
 
 
@@ -616,7 +649,7 @@ viewReadyCart ctx { votersIntents, maxResources, currentResources, txFinalized }
             else
                 div [] <|
                     (Html.h3 [] [ text "Votes ready for submission" ]
-                        :: List.map viewVoterIntents (Dict.toList votersIntents)
+                        :: List.map (viewVoterIntents ctx) (Dict.toList votersIntents)
                     )
     in
     div []

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -61,6 +61,7 @@ import List.Extra
 import Markdown.Block
 import Markdown.Parser as Md
 import Natural
+import Page.Cart as Cart
 import Platform.Cmd as Cmd
 import ProposalMetadata exposing (AuthorWitness, ProposalMetadata)
 import RemoteData exposing (RemoteData, WebData)
@@ -500,6 +501,7 @@ type MsgToParent
     | CachePoolInfo PoolInfo
     | CacheVoterGovId Gov.Id
     | CacheStorageConfig StorageConfig
+    | AddVoteToCart Witness.Voter Cart.VoteRecord
     | RunTask (ConcurrentTask String TaskCompleted)
     | BatchToParent MsgToParent MsgToParent
 
@@ -577,6 +579,7 @@ type Msg
     | GotIpfsAnswer (Result String IpfsAnswer)
     | AddOtherStorageButtonCLicked
       -- Build Tx Step
+    | AddVoteToCartButtonClicked Vote
     | BuildTxButtonClicked Vote
     | ChangeVoteButtonClicked
 
@@ -1177,6 +1180,31 @@ innerUpdate ctx msg model =
                     ( { model | permanentStorageStep = Preparing prep }
                     , Cmd.none
                     , Nothing
+                    )
+
+        --
+        -- Add Vote to Cart
+        --
+        AddVoteToCartButtonClicked vote ->
+            case allPrepSteps ctx model of
+                Err error ->
+                    ( { model | buildTxStep = Preparing { error = Just error } }
+                    , Cmd.none
+                    , Nothing
+                    )
+
+                Ok { voter, actionId, proposalTitle, rationaleAnchor } ->
+                    let
+                        voteIntent =
+                            { actionId = actionId
+                            , vote = vote
+                            , rationale = Just rationaleAnchor
+                            }
+                    in
+                    -- TODO: update the model to mark proposals already in the cart
+                    ( model
+                    , Cmd.none
+                    , Just <| AddVoteToCart voter <| Cart.VoteRecord proposalTitle voteIntent
                     )
 
         --
@@ -2551,6 +2579,7 @@ handleRationaleIpfsAnswer model ipfsAnswer =
 type alias TxRequirements =
     { voter : Witness.Voter
     , actionId : ActionId
+    , proposalTitle : String
     , rationaleAnchor : Anchor
     , localStateUtxos : Utxo.RefDict Output
     , walletAddress : Address
@@ -2562,9 +2591,20 @@ allPrepSteps : { a | loadedWallet : Maybe LoadedWallet, costModels : Maybe CostM
 allPrepSteps { loadedWallet, costModels } m =
     case ( costModels, ( m.voterStep, m.pickProposalStep, m.rationaleSignatureStep ), ( m.permanentStorageStep, loadedWallet ) ) of
         ( Just theCostModels, ( Done _ voter, Done _ p, Done _ r ), ( Done _ s, Just { utxos, wallet } ) ) ->
+            let
+                proposalTitle =
+                    case p.metadata of
+                        RemoteData.Success metadata ->
+                            metadata.body.title
+                                |> Maybe.withDefault "??? Unknown Proposal Title"
+
+                        _ ->
+                            "??? Unknown Proposal Title"
+            in
             Ok
                 { voter = voter
                 , actionId = p.id
+                , proposalTitle = proposalTitle
                 , rationaleAnchor =
                     { url = "ipfs://" ++ s.jsonFile.cid
                     , dataHash =
@@ -4115,9 +4155,9 @@ viewBuildTxStep ctx model =
                         , HA.style "flex-wrap" "wrap"
                         , HA.style "gap" "1rem"
                         ]
-                        [ Helper.voteButton "Vote YES" "#10B981" (BuildTxButtonClicked Gov.VoteYes)
-                        , Helper.voteButton "Vote NO" "#EF4444" (BuildTxButtonClicked Gov.VoteNo)
-                        , Helper.voteButton "ABSTAIN" "#6B7280" (BuildTxButtonClicked Gov.VoteAbstain)
+                        [ Helper.voteButton "Vote YES" "#10B981" (AddVoteToCartButtonClicked Gov.VoteYes)
+                        , Helper.voteButton "Vote NO" "#EF4444" (AddVoteToCartButtonClicked Gov.VoteNo)
+                        , Helper.voteButton "ABSTAIN" "#6B7280" (AddVoteToCartButtonClicked Gov.VoteAbstain)
                         ]
                     , viewError error
                     ]

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -59,7 +59,7 @@ import List.Extra
 import Markdown.Block
 import Markdown.Parser as Md
 import Natural
-import Page.Cart as Cart
+import Page.Cart as Cart exposing (VoteRecord)
 import Platform.Cmd as Cmd
 import ProposalMetadata exposing (AuthorWitness, ProposalMetadata)
 import RemoteData exposing (RemoteData, WebData)
@@ -2568,6 +2568,7 @@ type alias ViewContext msg =
     , loadedWallet : Maybe LoadedWallet
     , drepId : Maybe (Bytes CredentialHash)
     , epoch : Maybe Int
+    , cart : Cart.Model
     , proposals : WebData (Dict String ActiveProposal)
     , jsonLdContexts : JsonLdContexts
     , costModels : Maybe CostModels
@@ -2991,12 +2992,17 @@ viewProposalSelectionForm ctx model =
                     ]
 
             RemoteData.Success proposalsDict ->
-                viewProposalList ctx proposalsDict model.visibleProposalCount
+                case model.voterStep of
+                    Done _ voter ->
+                        viewProposalList ctx (Just voter) proposalsDict model.visibleProposalCount
+
+                    _ ->
+                        viewProposalList ctx Nothing proposalsDict model.visibleProposalCount
         ]
 
 
-viewProposalList : ViewContext msg -> Dict String ActiveProposal -> Int -> Html msg
-viewProposalList ctx proposalsDict visibleCount =
+viewProposalList : ViewContext msg -> Maybe Witness.Voter -> Dict String ActiveProposal -> Int -> Html msg
+viewProposalList ctx maybeVoter proposalsDict visibleCount =
     if Dict.isEmpty proposalsDict then
         div [ HA.style "text-align" "center", HA.style "padding" "2rem", HA.style "color" "#666" ]
             [ text "No active proposals found." ]
@@ -3006,9 +3012,26 @@ viewProposalList ctx proposalsDict visibleCount =
             currentEpoch =
                 Maybe.withDefault 0 ctx.epoch
 
-            allProposals =
+            proposalsDictValues =
                 Dict.values proposalsDict
-                    |> List.filter (\p -> p.epoch_validity.end > currentEpoch)
+
+            maybeVoterId =
+                Maybe.map (Witness.toVoter >> Gov.voterToId >> Gov.idToBech32) maybeVoter
+
+            -- Remove proposals already in the cart from that list for this voter
+            allProposals =
+                case maybeVoterId of
+                    Just voterId ->
+                        proposalsDictValues
+                            |> List.filter
+                                (\p ->
+                                    (p.epoch_validity.end > currentEpoch)
+                                        && not (Cart.contains voterId p.id ctx.cart)
+                                )
+
+                    Nothing ->
+                        proposalsDictValues
+                            |> List.filter (\p -> p.epoch_validity.end > currentEpoch)
 
             totalProposalCount =
                 List.length allProposals
@@ -3019,6 +3042,17 @@ viewProposalList ctx proposalsDict visibleCount =
 
             hasMore =
                 totalProposalCount > visibleCount
+
+            -- Filter proposals already in the cart for this voter
+            proposalsInCart : List VoteRecord
+            proposalsInCart =
+                case maybeVoterId of
+                    Nothing ->
+                        []
+
+                    Just voterId ->
+                        proposalsDictValues
+                            |> List.filterMap (\p -> Cart.get voterId p.id ctx.cart)
         in
         div []
             [ Helper.proposalListContainer
@@ -3030,6 +3064,7 @@ viewProposalList ctx proposalsDict visibleCount =
                 visibleCount
                 totalProposalCount
                 (ctx.wrapMsg (ShowMoreProposals visibleCount))
+            , Helper.viewProposalsListInCart proposalsInCart
             ]
 
 

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -31,14 +31,12 @@ import Bytes as ElmBytes
 import Bytes.Comparable as Bytes exposing (Bytes)
 import Cardano.Address as Address exposing (Address, Credential(..), CredentialHash, NetworkId(..))
 import Cardano.Cip30 as Cip30
-import Cardano.CoinSelection as CoinSelection
 import Cardano.Gov as Gov exposing (ActionId, Anchor, CostModels, Id(..), Vote)
 import Cardano.Pool as Pool
 import Cardano.Script as Script
 import Cardano.Transaction as Transaction exposing (Transaction, VKeyWitness)
 import Cardano.TxExamples exposing (prettyTx)
-import Cardano.TxIntent as TxIntent exposing (Fee(..), TxFinalized)
-import Cardano.Uplc as Uplc
+import Cardano.TxIntent exposing (TxFinalized)
 import Cardano.Utxo as Utxo exposing (Output, OutputReference, TransactionId)
 import Cardano.Witness as Witness
 import Cbor.Encode
@@ -580,7 +578,6 @@ type Msg
     | AddOtherStorageButtonCLicked
       -- Build Tx Step
     | AddVoteToCartButtonClicked Vote
-    | BuildTxButtonClicked Vote
     | ChangeVoteButtonClicked
 
 
@@ -1206,85 +1203,6 @@ innerUpdate ctx msg model =
                     , Cmd.none
                     , Just <| AddVoteToCart voter <| Cart.VoteRecord proposalTitle voteIntent
                     )
-
-        --
-        -- Build Tx Step
-        --
-        BuildTxButtonClicked vote ->
-            case allPrepSteps ctx model of
-                Err error ->
-                    ( { model | buildTxStep = Preparing { error = Just error } }
-                    , Cmd.none
-                    , Nothing
-                    )
-
-                Ok { voter, actionId, rationaleAnchor, localStateUtxos, walletAddress, costModels } ->
-                    let
-                        -- Use any address (enterprise / full) with the same payment cred
-                        -- as the one from the default wallet address to pay the fee
-                        walletOutputs =
-                            Dict.Any.values localStateUtxos
-
-                        potentialFeeSources =
-                            case Address.extractPubKeyHash walletAddress of
-                                Just paymentCred ->
-                                    walletOutputs
-                                        |> List.map (\output -> output.address)
-                                        |> List.filter (\addr -> Address.extractPubKeyHash addr == Just paymentCred)
-
-                                Nothing ->
-                                    []
-
-                        -- Helper function to gather free Ada for a given address
-                        -- Convert Natural amounts to Int (1 = 1 ada) for easy comparison
-                        freeAdaForAddress address =
-                            let
-                                freeAda output =
-                                    if output.address == address then
-                                        Utxo.freeAda output
-
-                                    else
-                                        Natural.zero
-                            in
-                            walletOutputs
-                                |> List.foldl (\output sum -> Natural.add sum <| freeAda output) Natural.zero
-                                -- divide by 1000000 to get ada amount from lovelace amount
-                                |> (\n -> n |> Natural.divBy (Natural.fromSafeInt 1000000))
-                                |> Maybe.withDefault Natural.zero
-                                |> Natural.toInt
-
-                        -- Pick the one with most free Ada as the payment source
-                        feeSource =
-                            List.sortBy freeAdaForAddress potentialFeeSources
-                                |> List.reverse
-                                |> List.head
-                                |> Maybe.withDefault walletAddress
-
-                        tryTx =
-                            [ TxIntent.Vote voter [ { actionId = actionId, vote = vote, rationale = Just rationaleAnchor } ]
-                            ]
-                                |> TxIntent.finalizeAdvanced
-                                    { govState = TxIntent.emptyGovernanceState
-                                    , localStateUtxos = localStateUtxos
-                                    , coinSelectionAlgo = CoinSelection.largestFirst
-                                    , evalScriptsCosts = Uplc.evalScriptsCosts Uplc.defaultVmConfig
-                                    , costModels = costModels
-                                    }
-                                    (AutoFee { paymentSource = feeSource })
-                                    []
-                    in
-                    case tryTx of
-                        Err error ->
-                            ( { model | buildTxStep = Preparing { error = Just <| "Error while building the Tx: " ++ TxIntent.errorToString error } }
-                            , Cmd.none
-                            , Nothing
-                            )
-
-                        Ok tx ->
-                            ( { model | buildTxStep = Done { error = Nothing } tx }
-                            , Cmd.none
-                            , Nothing
-                            )
 
         ChangeVoteButtonClicked ->
             ( { model | buildTxStep = Preparing { error = Nothing } }


### PR DESCRIPTION
This PR is a WIP.

The goal is to enable multi-vote transactions, which may contain multiple votes for the same or for different voters. A single Tx can typically contain around 100 votes. So an actor voting as a CC, a DRep and a SPO could bundle all of their votes in a single Tx for roughly 30 proposals at a time.

If we want to provide multi-vote with the same reliability of the current setup for single-vote transactions, there are a few things that need changing, considering the time spent in the app.

Most importantly, if multiple votes are stored in a voting cart, the cart needs to be also stored in local db/storage in the browser to avoid the frustration of potentially losing a ton of work when leaving the app.

As a consequence, we need to be able to serialize/deserialize the vote intentions with the corresponding voter. For Key, Native Multisig voters, this is fairly easy. However, for Script voters, it may not be possible to guarantee the correct serialization of the voter redeemers, because they can be built as functions of the Plutus Tx context. What we can do is consider the optimistic case where the redeemers are functions independent of the Plutus Tx context. In any case, we don’t have any Plutus Script voters yet, so this should not be a blocker, and left as a future improvement.

Another important improvement, in the context of multi-vote, is identifying easily which proposals are already in the cart, or have already been voted on. We might want to add visual indicators, or even split the list of available proposals.

Another important improvement, which was also asked for without multi-vote, is the ability to use a rationale published independently. Two situations can arise.
- First is when we build the rationale within the app, publish it via another mean, and use the independently-published url.
- Second is when we don’t want to build the rationale within the app because it was already done elsewhere, and we just want to re-use the independently published url.

That second case could be common in the case of multi-vote, with a single rationale explaining the whole set of votes. In that situation, the rationale could be built in-app (or independently) while creating the first vote, and then re-used when building the other votes.

Finally, in the Cart page, we need to know the resources spent by the multi-vote Tx so that we don’t go over budget. Doing so requires being able to build the Tx, which means resources can only reported after connecting a wallet and building a Tx with a given set of votes. We could be able to estimate resources without building the Tx, but they can change widely depending on the state of the wallet being used to build the Tx. Especially if the wallet does not contain any lightweight UTxO with only Ada or few tokens in it. We might need to have to improve the UTxO selection algorthim used to build the Tx, as currently, it’s a simple largest-first strategy.

Ok, enough talking, here is the current readiness level of this PR:

- [x] add a vote to the cart
- [x] remove a vote in the cart
- [x] save/reload the cart
- [x] build the Tx with votes in the cart
- [x] compute the Tx resources spent
- [x] remove submitted votes from cart on Tx submission
- [x] button to clear the cart
- [x] mark proposals in the list already in the cart
- [ ] mark proposals in the list already voted on in the past (todo in a follow up PR)
- [ ] enable external URLs for rationales (todo in a follow up PR)
- [ ] make it pretty and good UX