### PR TITLE
Remove home navigation link in header menu

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -1326,11 +1326,7 @@ viewHeader : Model -> Html Msg
 viewHeader model =
     let
         navigationItems =
-            [ { label = "Home"
-              , link = link RouteLanding
-              , isActive = model.page == LandingPage
-              }
-            , { label = "Vote Preparation"
+            [ { label = "Vote Preparation"
               , link = link <| RoutePreparation { networkId = model.networkId }
               , isActive =
                     case model.page of


### PR DESCRIPTION
Basically, this header menu link takes space and isn’t useful considering it has the exact same role as the CF logo, taking back to the home page. So better remove it for better space utilization.