### PR TITLE
Confirm reloaded voter

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -1197,10 +1197,17 @@ handleCompletedTask response model =
         ( ConcurrentTask.Success Ignore, _ ) ->
             ( model, Cmd.none )
 
-        ( ConcurrentTask.Success (GotLastVoter maybeGovId), _ ) ->
-            ( model
-            , Cmd.Extra.perform <| PreparationPageMsg <| Page.Preparation.setLastVoter maybeGovId
+        ( ConcurrentTask.Success (GotLastVoter maybeGovId), PreparationPage pageModel ) ->
+            let
+                ( newPageModel, pageCmd ) =
+                    Page.Preparation.setLastVoter maybeGovId pageModel
+            in
+            ( { model | page = PreparationPage newPageModel }
+            , Cmd.map PreparationPageMsg pageCmd
             )
+
+        ( ConcurrentTask.Success (GotLastVoter _), _ ) ->
+            ( model, Cmd.none )
 
         ( ConcurrentTask.Success (GotLastStorageConfig storageConfig), PreparationPage pageModel ) ->
             let

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -703,7 +703,7 @@ innerUpdate ctx msg model =
                         { model | reloadedLastVoter = False }
                       -- If we are reloading the last voter,
                       -- confirm automatically the voter’s gov ID.
-                    , if model.reloadedLastVoter then
+                    , if model.reloadedLastVoter && isKeyVoter govId then
                         Cmd.map ctx.wrapMsg <|
                             Cmd.batch [ cmd, Cmd.Extra.perform ValidateVoterFormButtonClicked ]
 
@@ -1336,6 +1336,24 @@ updateVoterForm f ({ voterStep } as model) =
 
         Done form done ->
             { model | voterStep = Done (f form) done }
+
+
+{-| Check if the voter is using a public key and not a script.
+-}
+isKeyVoter : Gov.Id -> Bool
+isKeyVoter govId =
+    case govId of
+        Gov.CcHotCredId (VKeyHash _) ->
+            True
+
+        Gov.DrepId (VKeyHash _) ->
+            True
+
+        Gov.PoolId _ ->
+            True
+
+        _ ->
+            False
 
 
 type alias GovIdCheck =

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -40,6 +40,7 @@ import Cardano.TxIntent exposing (TxFinalized)
 import Cardano.Utxo as Utxo exposing (Output, OutputReference, TransactionId)
 import Cardano.Witness as Witness
 import Cbor.Encode
+import Cmd.Extra
 import ConcurrentTask exposing (ConcurrentTask)
 import ConcurrentTask.Extra
 import ConcurrentTask.Http
@@ -85,6 +86,7 @@ Each step uses the Step type to track its progress.
 -}
 type alias InnerModel =
     { someRefUtxos : Utxo.RefDict Output
+    , reloadedLastVoter : Bool
     , voterStep : Step VoterPreparationForm Witness.Voter Witness.Voter
     , pickProposalStep : Step {} {} ActiveProposal
     , storageConfigStep : Step StorageForm {} StorageConfig
@@ -116,6 +118,7 @@ init : { label : String, description : String } -> Model
 init ipfsPreconfig =
     Model
         { someRefUtxos = Utxo.emptyRefDict
+        , reloadedLastVoter = False
         , voterStep = Preparing initVoterForm
         , pickProposalStep = Preparing {}
         , storageConfigStep = Done (initStorageForm ipfsPreconfig) (UsePreconfigIpfs ipfsPreconfig)
@@ -674,13 +677,13 @@ innerUpdate ctx msg model =
         VoterGovIdChange govIdStr ->
             case ( govIdStr, checkGovId ctx govIdStr ) of
                 ( "", _ ) ->
-                    ( updateVoterForm (\_ -> initVoterForm) model
+                    ( updateVoterForm (\_ -> initVoterForm) { model | reloadedLastVoter = False }
                     , Cmd.none
                     , Nothing
                     )
 
                 ( _, Err error ) ->
-                    ( updateVoterForm (\_ -> { initVoterForm | error = Just error }) model
+                    ( updateVoterForm (\_ -> { initVoterForm | error = Just error }) { model | reloadedLastVoter = False }
                     , Cmd.none
                     , Nothing
                     )
@@ -697,8 +700,15 @@ innerUpdate ctx msg model =
                                 , poolInfo = poolInfo
                             }
                         )
-                        model
-                    , Cmd.map ctx.wrapMsg cmd
+                        { model | reloadedLastVoter = False }
+                      -- If we are reloading the last voter,
+                      -- confirm automatically the voter’s gov ID.
+                    , if model.reloadedLastVoter then
+                        Cmd.map ctx.wrapMsg <|
+                            Cmd.batch [ cmd, Cmd.Extra.perform ValidateVoterFormButtonClicked ]
+
+                      else
+                        Cmd.map ctx.wrapMsg cmd
                     , msgToParent
                     )
 
@@ -1305,11 +1315,14 @@ handleTaskCompleted task (Model model) =
 -- Voter Step
 
 
-setLastVoter : Maybe Gov.Id -> Msg
-setLastVoter maybeGovId =
-    Maybe.map Gov.idToBech32 maybeGovId
+setLastVoter : Maybe Gov.Id -> Model -> ( Model, Cmd Msg )
+setLastVoter maybeGovId (Model model) =
+    ( Model { model | reloadedLastVoter = True }
+    , Maybe.map Gov.idToBech32 maybeGovId
         |> Maybe.withDefault ""
         |> VoterGovIdChange
+        |> Cmd.Extra.perform
+    )
 
 
 updateVoterForm : (VoterPreparationForm -> VoterPreparationForm) -> InnerModel -> InnerModel
@@ -1318,8 +1331,11 @@ updateVoterForm f ({ voterStep } as model) =
         Preparing form ->
             { model | voterStep = Preparing (f form) }
 
-        _ ->
-            model
+        Validating form validating ->
+            { model | voterStep = Validating (f form) validating }
+
+        Done form done ->
+            { model | voterStep = Done (f form) done }
 
 
 type alias GovIdCheck =


### PR DESCRIPTION
When I previously added the auto-reload of the last used voter ID, it consisted in just loading the gov ID from the local DB and reset the gov ID field with that one. However, we did not also "confirm" the voter ID, because we still needed to wait for additional voter info to be loaded, such as DRep info, or SPO info, or script info for a script DRep. So we saved the time for the DRep to re-enter their ID, but they would still need to "confirm" it after that additional information was fetched with followup koios requests.

Now, in the spirit of saving one more confirmation, this PR also auto-confirms the reloaded gov ID. To do that, we basically create an additional message simulating a click on the confirmation button. However we don’t want to auto-confirm all the time the gov ID field changes, but just in the case where it changes due to reloading the page and latest gov ID used. So we added a `reloadedLastVoter` boolean field in the prep page model for this.

Also, we needed to modify the handling of the DRep info / CC info / SPO info messages to also be processed when a the user was already confirmed. Otherwise we could not display things like voting power in the confirmed state.

The one downside is that script users will now see this error message: "Script info still loading, please wait". Because we cannot confirm a script user without the script info still being loaded. This is the case for the CF which is a script user. So they still have to wait for the script info to finish loading, and then manually click on "Confirm Voter".

But for 99% of (non-script) voters, this will save some time.

<img width="775" height="250" alt="image" src="https://github.com/user-attachments/assets/e0c304f2-94df-4823-8813-a8d34ccb9e87" />
