### PR TITLE
Fix last storage config reload

### DIFF
--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -333,7 +333,12 @@ type alias StorageForm =
 
 initStorageForm : { label : String, description : String } -> StorageForm
 initStorageForm ipfsPreconfig =
-    { storageMethod = PreconfigIPFS ipfsPreconfig
+    initStorageFormWithMethod <| PreconfigIPFS ipfsPreconfig
+
+
+initStorageFormWithMethod : StorageMethod -> StorageForm
+initStorageFormWithMethod method =
+    { storageMethod = method
     , nmkrUserId = ""
     , nmkrApiToken = ""
     , blockfrostProjectId = ""
@@ -341,6 +346,34 @@ initStorageForm ipfsPreconfig =
     , headers = [ ( "Authorization", "Basic {token}" ) ]
     , error = Nothing
     }
+
+
+storageFormFromConfig : StorageConfig -> StorageForm
+storageFormFromConfig config =
+    case config of
+        UsePreconfigIpfs preconfig ->
+            initStorageForm preconfig
+
+        UseBlockfrostIpfs { projectId } ->
+            let
+                form =
+                    initStorageFormWithMethod BlockfrostIPFS
+            in
+            { form | blockfrostProjectId = projectId }
+
+        UseNmkrIpfs { userId, apiToken } ->
+            let
+                form =
+                    initStorageFormWithMethod NmkrIPFS
+            in
+            { form | nmkrUserId = userId, nmkrApiToken = apiToken }
+
+        UseCustomIpfs { ipfsServer, headers } ->
+            let
+                form =
+                    initStorageFormWithMethod CustomIPFS
+            in
+            { form | ipfsServer = ipfsServer, headers = headers }
 
 
 type StorageConfig
@@ -1709,35 +1742,8 @@ utxoRefFromStr str =
 
 setLastStorageConfig : StorageConfig -> Model -> ( Model, Msg )
 setLastStorageConfig storageConfig (Model innerModel) =
-    let
-        form =
-            case storageConfig of
-                UsePreconfigIpfs labelAndDescription ->
-                    initStorageForm labelAndDescription
-
-                UseBlockfrostIpfs { label, description, projectId } ->
-                    let
-                        empty =
-                            initStorageForm { label = label, description = description }
-                    in
-                    { empty | blockfrostProjectId = projectId }
-
-                UseNmkrIpfs { label, description, userId, apiToken } ->
-                    let
-                        empty =
-                            initStorageForm { label = label, description = description }
-                    in
-                    { empty | nmkrUserId = userId, nmkrApiToken = apiToken }
-
-                UseCustomIpfs { label, description, ipfsServer, headers } ->
-                    let
-                        empty =
-                            initStorageForm { label = label, description = description }
-                    in
-                    { empty | ipfsServer = ipfsServer, headers = headers }
-    in
-    ( Model { innerModel | storageConfigStep = Preparing form }
-    , ValidateStorageConfigButtonClicked
+    ( Model { innerModel | storageConfigStep = Done (storageFormFromConfig storageConfig) storageConfig }
+    , NoMsg
     )
 
 


### PR DESCRIPTION
There was a mistake in my handling of the reloading of the latest storage config used. The mistake basically always used the "Preconfig" variant but with descriptions matching the other variants, resulting in always using the preconfig one instead of the actual expected storage config, such as blockfrost or nmkr or custom.

This fixes the reload logic to use the adequate storage method now.