### PR TITLE
UI stuff

### DIFF
--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -5,7 +5,7 @@ module Helper exposing
     , viewButton, viewWalletButton, externalLink, externalLinkButton
     , applyDropdownContainerStyle, applyDropdownItemStyle, applyMobileDropdownContainerStyle, applyWalletIconContainerStyle, applyWalletIconStyle
     , viewActionTypeIcon
-    , sectionTitle, infoBox, viewError
+    , sectionTitle, viewError
     , renderMarkdownContent
     , viewStepWithCircle, viewPageHeader
     , PreconfVoter, viewVoterGrid, viewVoterCard, voterCustomCard, votingPowerDisplay, scriptInfoContainer, viewVoterCredDetails, viewVoterDetailsItem, viewCredInfo
@@ -17,8 +17,8 @@ module Helper exposing
     , rationaleCompletedCard, optionalSection, formattedInternalVote, formattedReferences
     , stepNotAvailableCard, downloadJSONButton, authorsCard, addAuthorButton, codeSnippetBox, noAuthorsPlaceholder
     , signerCard, authorForm, labeledField, readOnlyField, signatureField, formButtonsRow, secondaryButton, primaryButton, loadSignatureButton
-    , stepCard, txResultCard, voteButton, txDetailsContainer, txPreContainer, missingStepsList, missingStepItem, loadingSpinner
-    , signingStepCard, keyListItem, signingButton
+    , stepCard, voteButton, missingStepsList, missingStepItem, loadingSpinner
+    , signingButton
     )
 
 {-| Helper module for miscellaneous functions that didn't fit elsewhere,
@@ -57,7 +57,7 @@ and are potentially useful in multiple places.
 
 # UI Structure Components
 
-@docs sectionTitle, infoBox, viewError
+@docs sectionTitle, viewError
 
 
 # Markdown Processing
@@ -101,12 +101,12 @@ and are potentially useful in multiple places.
 
 # Transaction Components
 
-@docs stepCard, txResultCard, voteButton, txDetailsContainer, txPreContainer, missingStepsList, missingStepItem, loadingSpinner
+@docs stepCard, voteButton, missingStepsList, missingStepItem, loadingSpinner
 
 
 # Signing Components
 
-@docs signingStepCard, keyListItem, signingButton
+@docs signingButton
 
 -}
 
@@ -544,25 +544,6 @@ cardContent attributes content =
 
 
 -- INFORMATION BOXES ###########################################################
-
-
-{-| Standard information box for displaying notices
--}
-infoBox : List (Html.Attribute msg) -> List (Html msg) -> Html msg
-infoBox attributes content =
-    div
-        ([ HA.style "background-color" "#F9FAFB"
-         , HA.style "border" "1px solid #E2E8F0"
-         , HA.style "border-radius" "0.5rem"
-         , HA.style "padding" "1rem"
-         , HA.style "margin-bottom" "1rem"
-         ]
-            ++ attributes
-        )
-        content
-
-
-
 -- FORM INPUT STYLING #########################################################
 -- UI COMPONENTS ##############################################################
 
@@ -2643,23 +2624,6 @@ stepCard content =
         [ cardContent [] content ]
 
 
-{-| Creates a transaction result card with header and status badge
--}
-txResultCard : String -> String -> List (Html msg) -> Html msg
-txResultCard title subtitle content =
-    cardContainer []
-        [ cardHeader
-            [ HA.style "display" "flex"
-            , HA.style "justify-content" "space-between"
-            , HA.style "align-items" "center"
-            ]
-            title
-            subtitle
-            [ successBadge "Ready" ]
-        , cardContent [] content
-        ]
-
-
 {-| Success badge used to show completed status
 -}
 successBadge : String -> Html msg
@@ -2698,37 +2662,6 @@ voteButton label color clickMsg =
         , onClick clickMsg
         ]
         [ text label ]
-
-
-{-| Monospaced container for transaction details
--}
-txDetailsContainer : List (Html msg) -> Html msg
-txDetailsContainer content =
-    div
-        [ HA.style "background-color" "#F9FAFB"
-        , HA.style "border" "1px solid #E2E8F0"
-        , HA.style "border-radius" "0.5rem"
-        , HA.style "padding" "1rem"
-        , HA.style "margin-bottom" "1.5rem"
-        , HA.style "overflow-x" "auto"
-        ]
-        content
-
-
-{-| Pre-formatted text container for code/json
--}
-txPreContainer : String -> Html msg
-txPreContainer content =
-    Html.pre
-        [ HA.style "font-family" "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace"
-        , HA.style "font-size" "0.875rem"
-        , HA.style "white-space" "pre-wrap"
-        , HA.style "word-break" "break-all"
-        , HA.style "max-height" "300px"
-        , HA.style "overflow-y" "auto"
-        , HA.style "margin" "0"
-        ]
-        [ text content ]
 
 
 {-| Missing steps list container
@@ -2848,52 +2781,6 @@ loadingSpinner message =
 
 
 -- TX SIGNING STEP STYLING #########################################################
-
-
-{-| Renders a card for the signing step with consistent styling
--}
-signingStepCard : String -> String -> List (Html msg) -> Html msg
-signingStepCard title description content =
-    cardContainer []
-        [ cardHeader [] title "" []
-        , cardContent []
-            [ Html.p
-                [ HA.style "color" "#4A5568"
-                , HA.style "font-size" "0.9375rem"
-                , HA.style "margin-bottom" "1rem"
-                ]
-                [ text description ]
-            , div [] content
-            ]
-        ]
-
-
-{-| Renders a styled list item for a key/signature in the signing step
--}
-keyListItem : String -> String -> Html msg
-keyListItem keyName hashHex =
-    Html.li
-        [ HA.style "display" "flex"
-        , HA.style "flex-direction" "column"
-        , HA.style "padding-bottom" "0.75rem"
-        , HA.style "border-bottom" "1px solid #EDF2F7"
-        , HA.style "last:border-bottom" "none"
-        , HA.style "last:padding-bottom" "0"
-        ]
-        [ Html.div
-            [ HA.style "font-weight" "500"
-            , HA.style "color" "#4A5568"
-            , HA.style "margin-bottom" "0.25rem"
-            ]
-            [ text keyName ]
-        , Html.div
-            [ HA.style "font-family" "monospace"
-            , HA.style "font-size" "0.875rem"
-            , HA.style "color" "#718096"
-            , HA.style "word-break" "break-all"
-            ]
-            [ text hashHex ]
-        ]
 
 
 {-| Renders a standardized signing button with consistent styling

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -1209,6 +1209,9 @@ updateModelWithPrepToParentMsg msgToParent model =
             ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete } writeCartToDb
                 |> Tuple.mapFirst (\newTaskPool -> { model | taskPool = newTaskPool, cart = updatedCart })
 
+        Just Page.Preparation.GoToCart ->
+            handleUrlChange (RouteCart { networkId = model.networkId }) model
+
         Just (Page.Preparation.RunTask task) ->
             ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete }
                 (ConcurrentTask.map PreparationTaskCompleted task)

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -3751,17 +3751,11 @@ viewRationaleStep :
     -> Html msg
 viewRationaleStep ctx pickProposalStep storageConfigStep step =
     Html.map ctx.wrapMsg <|
-        case ( ( ctx.walletsDiscovered, pickProposalStep ), storageConfigStep, step ) of
-            ( ( [], _ ), _, _ ) ->
-                div []
-                    [ Helper.sectionTitle "Vote Rationale"
-                    , Helper.stepNotAvailableCard [ text "No Cardano wallet detected, you will not be able to create a transaction. Please make sure you are using the browser where your Cardano wallet is installed." ]
-                    ]
-
-            ( ( _, Done _ _ ), Done _ _, Preparing form ) ->
+        case ( pickProposalStep, storageConfigStep, step ) of
+            ( Done _ _, Done _ _, Preparing form ) ->
                 viewRationaleForm form
 
-            ( ( _, Done _ _ ), Done _ _, Validating _ _ ) ->
+            ( Done _ _, Done _ _, Validating _ _ ) ->
                 div []
                     [ Helper.sectionTitle "Vote Rationale"
                     , Helper.formContainer
@@ -3770,7 +3764,7 @@ viewRationaleStep ctx pickProposalStep storageConfigStep step =
                         ]
                     ]
 
-            ( ( _, Done _ _ ), Done _ _, Done _ rationale ) ->
+            ( Done _ _, Done _ _, Done _ rationale ) ->
                 viewCompletedRationale rationale
 
             ( _, Done _ _, _ ) ->
@@ -3779,7 +3773,7 @@ viewRationaleStep ctx pickProposalStep storageConfigStep step =
                     , Helper.stepNotAvailableCard [ text "Please pick a proposal first." ]
                     ]
 
-            ( ( _, Done _ _ ), _, _ ) ->
+            ( Done _ _, _, _ ) ->
                 div []
                     [ Helper.sectionTitle "Vote Rationale"
                     , Helper.stepNotAvailableCard [ text "Please validate the IPFS config step first." ]

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -3152,6 +3152,37 @@ viewProposalList ctx form maybeVoter proposalsDict visibleCount =
             maybeVoterId =
                 Maybe.map (Witness.toVoter >> Gov.voterToId >> Gov.idToBech32) maybeVoter
 
+            -- Helper function to filter proposals based on the current voter role
+            roleCanVoteOn actionType =
+                case maybeVoter of
+                    Nothing ->
+                        True
+
+                    Just (Witness.WithDrepCred _) ->
+                        True
+
+                    Just (Witness.WithPoolCred _) ->
+                        case actionType of
+                            "TreasuryWithdrawals" ->
+                                False
+
+                            "NewConstitution" ->
+                                False
+
+                            _ ->
+                                True
+
+                    Just (Witness.WithCommitteeHotCred _) ->
+                        case actionType of
+                            "NewCommittee" ->
+                                False
+
+                            "NoConfidence" ->
+                                False
+
+                            _ ->
+                                True
+
             -- Remove proposals already in the cart from that list for this voter
             allProposals =
                 case maybeVoterId of
@@ -3160,6 +3191,7 @@ viewProposalList ctx form maybeVoter proposalsDict visibleCount =
                             |> List.filter
                                 (\p ->
                                     (p.epoch_validity.end > currentEpoch)
+                                        && roleCanVoteOn p.actionType
                                         && not (Cart.contains voterId p.id ctx.cart)
                                 )
 

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -27,16 +27,15 @@ The steps are sequential but allow going back to modify previous steps.
 
 import Api exposing (ActiveProposal, CcInfo, DrepInfo, IpfsAnswer(..), OnchainVote, PoolInfo)
 import Blake2b exposing (blake2b256)
+import Browser.Dom
 import Bytes as ElmBytes
 import Bytes.Comparable as Bytes exposing (Bytes)
-import Cardano.Address as Address exposing (Address, Credential(..), CredentialHash, NetworkId(..))
+import Cardano.Address exposing (Credential(..), CredentialHash, NetworkId(..))
 import Cardano.Cip30 as Cip30
 import Cardano.Gov as Gov exposing (ActionId, Anchor, CostModels, Id(..), Vote)
 import Cardano.Pool as Pool
 import Cardano.Script as Script
 import Cardano.Transaction as Transaction exposing (Transaction, VKeyWitness)
-import Cardano.TxExamples exposing (prettyTx)
-import Cardano.TxIntent exposing (TxFinalized)
 import Cardano.Utxo as Utxo exposing (Output, OutputReference, TransactionId)
 import Cardano.Witness as Witness
 import Cbor.Encode
@@ -94,7 +93,7 @@ type alias InnerModel =
     , rationaleCreationStep : Step RationaleForm Rationale Rationale
     , rationaleSignatureStep : Step RationaleSignatureForm {} RationaleSignature
     , permanentStorageStep : Step { error : Maybe String } {} Storage
-    , buildTxStep : Step BuildTxPrep {} TxFinalized
+    , buildTxStep : Step BuildTxPrep {} {}
     , signTxStep : Step { error : Maybe String } SigningTx SignedTx
     , visibleProposalCount : Int
     }
@@ -539,6 +538,7 @@ type MsgToParent
     | CacheVoterGovId Gov.Id
     | CacheStorageConfig StorageConfig
     | AddVoteToCart Witness.Voter Cart.VoteRecord
+    | GoToCart
     | RunTask (ConcurrentTask String TaskCompleted)
     | BatchToParent MsgToParent MsgToParent
 
@@ -619,6 +619,8 @@ type Msg
       -- Build Tx Step
     | AddVoteToCartButtonClicked Vote
     | ChangeVoteButtonClicked
+    | PickAnotherProposalButtonClicked
+    | GoToCartButtonClicked
 
 
 {-| Configuration required by the update function.
@@ -1254,7 +1256,7 @@ innerUpdate ctx msg model =
         -- Add Vote to Cart
         --
         AddVoteToCartButtonClicked vote ->
-            case allPrepSteps ctx model of
+            case allPrepSteps model of
                 Err error ->
                     ( { model | buildTxStep = Preparing { error = Just error } }
                     , Cmd.none
@@ -1269,7 +1271,7 @@ innerUpdate ctx msg model =
                             , rationale = Just rationaleAnchor
                             }
                     in
-                    ( model
+                    ( { model | buildTxStep = Done { error = Nothing } {} }
                     , Cmd.none
                     , Just <| AddVoteToCart voter <| Cart.VoteRecord proposalTitle voteIntent
                     )
@@ -1278,6 +1280,21 @@ innerUpdate ctx msg model =
             ( { model | buildTxStep = Preparing { error = Nothing } }
             , Cmd.none
             , Nothing
+            )
+
+        PickAnotherProposalButtonClicked ->
+            ( { model
+                | buildTxStep = Preparing { error = Nothing }
+                , pickProposalStep = Preparing {}
+              }
+            , Task.perform (always <| ctx.wrapMsg NoMsg) (Browser.Dom.setViewport 0 1000000)
+            , Nothing
+            )
+
+        GoToCartButtonClicked ->
+            ( { model | buildTxStep = Preparing { error = Nothing } }
+            , Cmd.none
+            , Just GoToCart
             )
 
 
@@ -2630,16 +2647,13 @@ type alias TxRequirements =
     , actionId : ActionId
     , proposalTitle : String
     , rationaleAnchor : Anchor
-    , localStateUtxos : Utxo.RefDict Output
-    , walletAddress : Address
-    , costModels : CostModels
     }
 
 
-allPrepSteps : { a | loadedWallet : Maybe LoadedWallet, costModels : Maybe CostModels } -> InnerModel -> Result String TxRequirements
-allPrepSteps { loadedWallet, costModels } m =
-    case ( costModels, ( m.voterStep, m.pickProposalStep, m.rationaleSignatureStep ), ( m.permanentStorageStep, loadedWallet ) ) of
-        ( Just theCostModels, ( Done _ voter, Done _ p, Done _ r ), ( Done _ s, Just { utxos, wallet } ) ) ->
+allPrepSteps : InnerModel -> Result String TxRequirements
+allPrepSteps m =
+    case ( ( m.voterStep, m.pickProposalStep, m.rationaleSignatureStep ), m.permanentStorageStep ) of
+        ( ( Done _ voter, Done _ p, Done _ r ), Done _ s ) ->
             let
                 proposalTitle =
                     case p.metadata of
@@ -2662,13 +2676,7 @@ allPrepSteps { loadedWallet, costModels } m =
                             |> blake2b256 Nothing
                             |> Bytes.fromU8
                     }
-                , localStateUtxos = Dict.Any.union m.someRefUtxos utxos
-                , walletAddress = Cip30.walletChangeAddress wallet
-                , costModels = theCostModels
                 }
-
-        ( Nothing, _, _ ) ->
-            Err "Somehow cost models are missing, please report this issue"
 
         _ ->
             Err "Incomplete steps before Tx building"
@@ -2739,7 +2747,6 @@ view ctx (Model model) =
             , Helper.viewStepWithCircle 5 "rationale-signature-step" (viewRationaleSignatureStep ctx model.pickProposalStep model.rationaleCreationStep model.rationaleSignatureStep)
             , Helper.viewStepWithCircle 6 "storage-step" (viewPermanentStorageStep ctx model.rationaleSignatureStep model.storageConfigStep model.permanentStorageStep)
             , Html.map ctx.wrapMsg <| Helper.viewStepWithCircle 7 "build-tx-step" (viewBuildTxStep ctx model)
-            , Helper.viewStepWithCircle 8 "sign-tx-step" (viewSignTxStep ctx model.voterStep model.buildTxStep)
             ]
         ]
 
@@ -4263,10 +4270,10 @@ viewCompletedStorage r storage =
 viewBuildTxStep : ViewContext msg -> InnerModel -> Html Msg
 viewBuildTxStep ctx model =
     div []
-        [ Helper.sectionTitle "Tx Building"
-        , case ( allPrepSteps ctx model, model.buildTxStep ) of
+        [ Helper.sectionTitle "Vote"
+        , case ( allPrepSteps model, model.buildTxStep ) of
             ( Err _, _ ) ->
-                viewMissingStepsMessage ctx model
+                viewMissingStepsMessage model
 
             ( Ok _, Preparing { error } ) ->
                 Helper.stepCard
@@ -4291,27 +4298,50 @@ viewBuildTxStep ctx model =
             ( Ok _, Validating _ _ ) ->
                 Helper.loadingSpinner "Building transaction..."
 
-            ( Ok _, Done _ { tx } ) ->
+            ( Ok { voter, actionId }, Done _ _ ) ->
                 div []
-                    [ Helper.txResultCard
-                        "Transaction Built"
-                        "Your vote transaction has been created successfully"
-                        [ Html.p
-                            [ HA.style "color" "#4A5568"
-                            , HA.style "font-size" "0.9375rem"
-                            , HA.style "margin-bottom" "1rem"
+                    [ Helper.stepCard
+                        [ div
+                            [ HA.style "display" "flex"
+                            , HA.style "flex-wrap" "wrap"
+                            , HA.style "gap" "1rem"
+                            , HA.style "font-size" "1.5rem"
                             ]
-                            [ text "Transaction details (₳ displayed as lovelaces):" ]
-                        , Helper.txDetailsContainer
-                            [ Helper.txPreContainer <| prettyTx tx ]
+                            (viewVoteInCart voter actionId ctx.cart)
                         ]
                     , Helper.viewButton "Change vote" ChangeVoteButtonClicked
+                    , text " "
+                    , Helper.viewButton "Pick another proposal" PickAnotherProposalButtonClicked
+                    , text " "
+                    , Helper.viewButton "Go to Cart" GoToCartButtonClicked
                     ]
         ]
 
 
-viewMissingStepsMessage : ViewContext msg -> InnerModel -> Html Msg
-viewMissingStepsMessage ctx model =
+viewVoteInCart : Witness.Voter -> ActionId -> Cart.Model -> List (Html msg)
+viewVoteInCart voter actionId cart =
+    let
+        voterIdStr =
+            Witness.toVoter voter |> Gov.voterToId |> Gov.idToBech32
+    in
+    case Cart.get voterIdStr actionId cart of
+        Nothing ->
+            [ text "No vote found in cart. Try again picking a vote decision." ]
+
+        Just { voteIntent } ->
+            case voteIntent.vote of
+                Gov.VoteNo ->
+                    [ text "NO vote added to the cart." ]
+
+                Gov.VoteYes ->
+                    [ text "YES vote added to the cart." ]
+
+                Gov.VoteAbstain ->
+                    [ text "ABSTAIN vote added to the cart." ]
+
+
+viewMissingStepsMessage : InnerModel -> Html Msg
+viewMissingStepsMessage model =
     Helper.stepNotAvailableCard
         [ Html.p
             [ HA.style "color" "#4A5568"
@@ -4324,8 +4354,6 @@ viewMissingStepsMessage ctx model =
             , Helper.missingStepItem "Proposal selection" (isStepIncomplete model.pickProposalStep) (Just "proposal-step")
             , Helper.missingStepItem "Rationale creation" (isStepIncomplete model.rationaleCreationStep) (Just "rationale-step")
             , Helper.missingStepItem "Rationale storage" (isStepIncomplete model.permanentStorageStep) (Just "storage-step")
-            , Helper.missingStepItem "Connect wallet" (ctx.loadedWallet == Nothing) Nothing
-            , Helper.missingStepItem "Protocol parameters" (ctx.costModels == Nothing) Nothing
             ]
         ]
 
@@ -4338,129 +4366,6 @@ isStepIncomplete step =
 
         _ ->
             True
-
-
-
---
--- Tx Signing Step
---
-
-
-viewSignTxStep : ViewContext msg -> Step a b Witness.Voter -> Step BuildTxPrep {} TxFinalized -> Html msg
-viewSignTxStep ctx voterStep buildTxStep =
-    case ( buildTxStep, voterStep ) of
-        ( Done _ { tx, expectedSignatures }, Done _ voterWitness ) ->
-            let
-                voterId =
-                    case voterWitness of
-                        Witness.WithCommitteeHotCred (Witness.WithKey hotkey) ->
-                            [ ( Bytes.toHex hotkey, "Committee hot key" ) ]
-
-                        Witness.WithCommitteeHotCred (Witness.WithScript scriptHash witness) ->
-                            ( Bytes.toHex scriptHash, "Committee governance script" )
-                                :: extractMultisigKeys witness
-
-                        Witness.WithDrepCred (Witness.WithKey credKey) ->
-                            [ ( Bytes.toHex credKey, "DRep key" ) ]
-
-                        Witness.WithDrepCred (Witness.WithScript scriptHash witness) ->
-                            ( Bytes.toHex scriptHash, "DRep governance script" )
-                                :: extractMultisigKeys witness
-
-                        Witness.WithPoolCred poolKey ->
-                            [ ( Bytes.toHex poolKey, "SPO key" ) ]
-
-                extractMultisigKeys : Witness.Script -> List ( String, String )
-                extractMultisigKeys witness =
-                    case witness of
-                        Witness.Native { expectedSigners } ->
-                            List.map (\signer -> ( Bytes.toHex signer, "Multisig signer" )) expectedSigners
-
-                        Witness.Plutus _ ->
-                            []
-
-                walletSpendingCredential =
-                    case ctx.loadedWallet of
-                        Just { wallet } ->
-                            Address.extractPubKeyHash (Cip30.walletChangeAddress wallet)
-                                |> Maybe.map (\hash -> [ ( Bytes.toHex hash, "Wallet spending key" ) ])
-                                |> Maybe.withDefault []
-
-                        Nothing ->
-                            []
-
-                walletStakeCredential =
-                    case ctx.loadedWallet of
-                        Just { wallet } ->
-                            Address.extractStakeKeyHash (Cip30.walletChangeAddress wallet)
-                                |> Maybe.map (\hash -> [ ( Bytes.toHex hash, "Wallet stake key" ) ])
-                                |> Maybe.withDefault []
-
-                        Nothing ->
-                            []
-
-                keyNames : Dict String String
-                keyNames =
-                    Dict.fromList (voterId ++ walletSpendingCredential ++ walletStakeCredential)
-            in
-            div []
-                [ Helper.sectionTitle "Tx Signing"
-                , Helper.signingStepCard
-                    "Finalize Your Vote"
-                    "The following keys will need to sign the transaction:"
-                    [ Helper.infoBox []
-                        [ Html.ul
-                            [ HA.style "list-style-type" "none"
-                            , HA.style "padding" "0"
-                            , HA.style "margin" "0"
-                            , HA.style "display" "flex"
-                            , HA.style "flex-direction" "column"
-                            , HA.style "gap" "0.75rem"
-                            ]
-                            (List.map
-                                (\hash ->
-                                    let
-                                        hashHex =
-                                            Bytes.toHex hash
-
-                                        keyName =
-                                            Dict.get hashHex keyNames
-                                                |> Maybe.withDefault "Unknown key"
-                                    in
-                                    Helper.keyListItem keyName hashHex
-                                )
-                                expectedSignatures
-                            )
-                        ]
-                    , Html.p
-                        [ HA.style "color" "#4A5568"
-                        , HA.style "font-size" "0.9375rem"
-                        , HA.style "margin-bottom" "1.5rem"
-                        ]
-                        [ text "Click the button below to proceed to the signing page where you can sign and submit your voting transaction." ]
-                    ]
-                , ctx.signingLink tx
-                    (expectedSignatures
-                        |> List.map
-                            (\keyHash ->
-                                { keyHash = keyHash
-                                , keyName =
-                                    Dict.get (Bytes.toHex keyHash) keyNames
-                                        |> Maybe.withDefault "Key hash"
-                                }
-                            )
-                    )
-                    [ Helper.signingButton "Go to Signing Page" ]
-                ]
-
-        _ ->
-            div []
-                [ Helper.sectionTitle "Tx Signing"
-                , Helper.signingStepCard
-                    "Step Not Available"
-                    "Please complete the transaction building step first."
-                    []
-                ]
 
 
 


### PR DESCRIPTION
Improves a few functional aspects of the UI such as:
- filter proposals according to the confirmed voter role (e.g. the CC role cannot vote for no confidence or CC changes)
- convert the "Tx Build" step into a "Vote" step since now the tx building is done in the cart instead
- remove the checks for a connected wallet in the preparation page since now it’s only needed in the cart