### PR TITLE
Upgrade the cmarker typst dep to convert rationale markdown

### DIFF
--- a/backend/template.typ
+++ b/backend/template.typ
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // https://typst.app/universe/package/cmarker
-#import "@preview/cmarker:0.1.1"
+#import "@preview/cmarker:0.1.6"
 
 // JSON data
 #let data = json("metadata.json")


### PR DESCRIPTION
The upgraded version (0.1.6) has been stable since May 2025 and covers a lot more of the markdown syntax, including tables!
More info on the package: https://typst.app/universe/package/cmarker