### PR TITLE
Add feature to export/import the cart

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -338,6 +338,7 @@ type Msg
     | CartPageMsg Page.Cart.Msg
     | DeleteVote { voterIdStr : String, actionIdStr : String }
     | ClearCart
+    | SaveImportedCart
     | CartBroadcastReceived Value
       -- Multisig DRep registration page
     | MultisigPageMsg Page.MultisigRegistration.Msg
@@ -705,6 +706,7 @@ update msg model =
                     { wrapMsg = CartPageMsg
                     , costModels = Maybe.map .costModels model.protocolParams
                     , loadedWallet = loadedWallet
+                    , saveImportedCart = SaveImportedCart
                     }
 
                 ( updatedCart, cmds ) =
@@ -725,18 +727,11 @@ update msg model =
                 |> Tuple.mapFirst (\newTaskPool -> { model | taskPool = newTaskPool, cart = updatedCart })
                 |> Cmd.Extra.add (broadcastCart networkId updatedCart)
 
-        ( ClearCart, { networkId } ) ->
-            let
-                emptyCart =
-                    Page.Cart.init
+        ( ClearCart, _ ) ->
+            saveCart Page.Cart.init model
 
-                writeCartToDb =
-                    Storage.write { db = model.db, storeName = "app" } Page.Cart.serialize { key = "cart:" ++ networkIdToString networkId } emptyCart
-                        |> ConcurrentTask.map (always Ignore)
-            in
-            ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete } writeCartToDb
-                |> Tuple.mapFirst (\newTaskPool -> { model | taskPool = newTaskPool, cart = emptyCart })
-                |> Cmd.Extra.add (broadcastCart networkId emptyCart)
+        ( SaveImportedCart, _ ) ->
+            saveCart model.cart model
 
         ( CartBroadcastReceived value, _ ) ->
             let
@@ -1294,6 +1289,18 @@ updateModelWithPrepToParentMsg msgToParent model =
                         updateModelWithPrepToParentMsg (Just msg2) newModel
                             |> Tuple.mapSecond (\cmd2 -> Cmd.batch [ cmd1, cmd2 ])
                    )
+
+
+saveCart : Page.Cart.Model -> Model -> ( Model, Cmd Msg )
+saveCart cart model =
+    let
+        writeCartToDb =
+            Storage.write { db = model.db, storeName = "app" } Page.Cart.serialize { key = "cart:" ++ networkIdToString model.networkId } cart
+                |> ConcurrentTask.map (always Ignore)
+    in
+    ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete } writeCartToDb
+        |> Tuple.mapFirst (\newTaskPool -> { model | taskPool = newTaskPool, cart = cart })
+        |> Cmd.Extra.add (broadcastCart model.networkId cart)
 
 
 {-| Helper function to reset the signing step of the Preparation.

--- a/frontend/src/Page/Cart.elm
+++ b/frontend/src/Page/Cart.elm
@@ -24,6 +24,7 @@ import Json.Decode as JD
 import Json.Encode as JE
 import Natural as N
 import Task
+import Url
 
 
 {-| The Cart model has two states, preparing and ready.
@@ -793,14 +794,23 @@ viewPreparingCart ctx { votersIntents, error } =
                 , HA.style "align-items" "center"
                 , HA.style "justify-content" "space-between"
                 , HA.style "margin-bottom" "0.75rem"
+                , HA.style "flex-wrap" "wrap"
+                , HA.style "gap" "0.75rem"
                 ]
                 [ viewButton "Build Transaction" (ctx.wrapMsg BuildTx)
-                , Html.div []
-                    [ Helper.downloadJSONButton "Export Cart"
-                        { filename = "vote-cart.json"
-                        , rawJson = JE.encode 0 <| serializeVotersIntents votersIntents
-                        }
-                    , Helper.primaryButton "Import Cart" (ctx.wrapMsg ImportCartButtonClicked)
+                , Html.div
+                    [ HA.style "display" "flex"
+                    , HA.style "gap" "0.5rem"
+                    , HA.style "align-items" "center"
+                    , HA.style "flex-wrap" "wrap"
+                    ]
+                    [ Html.a
+                        [ HA.href <| "data:application/json;charset=utf-8," ++ Url.percentEncode (JE.encode 0 <| serializeVotersIntents votersIntents)
+                        , HA.download "vote-cart.json"
+                        , HA.style "text-decoration" "none"
+                        ]
+                        [ viewButton "Export Cart" (ctx.wrapMsg NoMsg) ]
+                    , viewButton "Import Cart" (ctx.wrapMsg ImportCartButtonClicked)
                     ]
                 ]
     in
@@ -817,7 +827,13 @@ viewPreparingCart ctx { votersIntents, error } =
             [ viewCartHeader
             , summaryBar
             , viewEmptyCart
-            , Helper.primaryButton "Import Cart" (ctx.wrapMsg ImportCartButtonClicked)
+            , Html.div
+                [ HA.style "display" "flex"
+                , HA.style "justify-content" "flex-end"
+                , HA.style "margin-bottom" "0.75rem"
+                , HA.style "flex-wrap" "wrap"
+                ]
+                [ viewButton "Import Cart" (ctx.wrapMsg ImportCartButtonClicked) ]
             , viewError error
             ]
 

--- a/frontend/src/Page/Cart.elm
+++ b/frontend/src/Page/Cart.elm
@@ -12,14 +12,18 @@ import Cardano.Uplc as Uplc
 import Cardano.Utils as Utils
 import Cardano.Utxo as Utxo exposing (Output)
 import Cardano.Witness as Witness exposing (Voter(..))
+import Cmd.Extra
 import Dict exposing (Dict)
 import Dict.Any
+import File exposing (File)
+import File.Select
 import Helper exposing (cardContainer, cardContent, cardHeader, sectionTitle, viewButton, viewError)
 import Html exposing (Html, div, text)
 import Html.Attributes as HA
 import Json.Decode as JD
 import Json.Encode as JE
 import Natural as N
+import Task
 
 
 {-| The Cart model has two states, preparing and ready.
@@ -127,7 +131,11 @@ getVoter voterId model =
 
 
 type Msg
-    = BuildTx
+    = NoMsg
+    | BuildTx
+    | ImportCartButtonClicked
+    | CartFileSelected File
+    | LoadedCart String
 
 
 type alias UpdateContext a msg =
@@ -135,12 +143,16 @@ type alias UpdateContext a msg =
         | wrapMsg : Msg -> msg
         , costModels : Maybe CostModels
         , loadedWallet : Maybe { wallet : Cip30.Wallet, utxos : Utxo.RefDict Output }
+        , saveImportedCart : msg
     }
 
 
 update : UpdateContext a msg -> Msg -> Model -> ( Model, Cmd msg )
 update ctx msg model =
     case ( ( ctx.loadedWallet, ctx.costModels ), msg, model ) of
+        ( _, NoMsg, _ ) ->
+            ( model, Cmd.none )
+
         ( ( Just { wallet, utxos }, Just costModels ), BuildTx, Preparing ({ votersIntents } as cartPrep) ) ->
             let
                 walletAddress =
@@ -187,10 +199,49 @@ update ctx msg model =
             ( Preparing { cartPrep | error = Just "We failed to load the cost models, maybe try to refresh." }, Cmd.none )
 
         ( ( Nothing, _ ), BuildTx, Preparing cartPrep ) ->
-            ( Preparing { cartPrep | error = Just "Please connect a wallet to build the transaction" }, Cmd.none )
+            ( Preparing { cartPrep | error = Just "Please connect a wallet to build the transaction, or export your cart and import it in your other browser with a wallet." }, Cmd.none )
 
         ( _, BuildTx, _ ) ->
             ( model, Cmd.none )
+
+        ( _, ImportCartButtonClicked, _ ) ->
+            ( model
+            , Cmd.map ctx.wrapMsg <|
+                File.Select.file [] CartFileSelected
+            )
+
+        ( _, CartFileSelected file, _ ) ->
+            ( model
+            , Task.attempt handleCartFileRead (File.toString file)
+                |> Cmd.map ctx.wrapMsg
+            )
+
+        ( _, LoadedCart cartJsonStr, _ ) ->
+            case JD.decodeString deserialize cartJsonStr of
+                Ok cartModel ->
+                    ( cartModel, Cmd.Extra.perform ctx.saveImportedCart )
+
+                Err error ->
+                    let
+                        reportError votersIntents errorStr =
+                            ( Preparing { votersIntents = votersIntents, error = Just errorStr }, Cmd.none )
+                    in
+                    case model of
+                        Preparing { votersIntents } ->
+                            reportError votersIntents (JD.errorToString error)
+
+                        Ready { votersIntents } ->
+                            reportError votersIntents (JD.errorToString error)
+
+
+handleCartFileRead : Result x String -> Msg
+handleCartFileRead result =
+    case result of
+        Err _ ->
+            NoMsg
+
+        Ok cartJsonStr ->
+            LoadedCart cartJsonStr
 
 
 
@@ -739,11 +790,19 @@ viewPreparingCart ctx { votersIntents, error } =
         actionsBar =
             div
                 [ HA.style "display" "flex"
-                , HA.style "gap" "0.75rem"
-                , HA.style "margin-top" "0.5rem"
-                , HA.style "margin-bottom" "1rem"
+                , HA.style "align-items" "center"
+                , HA.style "justify-content" "space-between"
+                , HA.style "margin-bottom" "0.75rem"
                 ]
-                [ viewButton "Build Transaction" (ctx.wrapMsg BuildTx) ]
+                [ viewButton "Build Transaction" (ctx.wrapMsg BuildTx)
+                , Html.div []
+                    [ Helper.downloadJSONButton "Export Cart"
+                        { filename = "vote-cart.json"
+                        , rawJson = JE.encode 0 <| serializeVotersIntents votersIntents
+                        }
+                    , Helper.primaryButton "Import Cart" (ctx.wrapMsg ImportCartButtonClicked)
+                    ]
+                ]
     in
     if hasVotes then
         div pageAttrs <|
@@ -758,6 +817,7 @@ viewPreparingCart ctx { votersIntents, error } =
             [ viewCartHeader
             , summaryBar
             , viewEmptyCart
+            , Helper.primaryButton "Import Cart" (ctx.wrapMsg ImportCartButtonClicked)
             , viewError error
             ]
 
@@ -962,7 +1022,7 @@ viewEmptyCart =
                     [ HA.style "color" "#6B7280"
                     , HA.style "font-size" "0.95rem"
                     ]
-                    [ text "Add votes from Vote Preparation page to see them here." ]
+                    [ text "Add votes from Vote Preparation page to see them here, or import a saved cart with the button below." ]
                 ]
             ]
         ]


### PR DESCRIPTION
Some users had to redo their voting after realizing they used the wrong browser to prepare the votes, because you need a Cardano wallet to build the Tx after preparation. So this small change enables exporting/importing the cart via a json file. This way, you can export the cart after realizing it was the wrong browser and import it in the correct one.