### PR TITLE
Add buttons shortcuts to add references to the constitution and proposal metadata

### DIFF
--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -50,6 +50,7 @@ So this is how there is a mix of regular `(...) -> Cmd msg` and `ConcurrentTask 
 type alias ApiProvider msg =
     { loadProtocolParams : NetworkId -> (Result Http.Error ProtocolParams -> msg) -> Cmd msg
     , queryEpoch : NetworkId -> (Result Http.Error Int -> msg) -> Cmd msg
+    , queryConstitution : NetworkId -> (Result Http.Error String -> msg) -> Cmd msg
     , loadGovProposals : NetworkId -> Int -> (Result Http.Error (List ActiveProposal) -> msg) -> Cmd msg
     , loadProposalMetadata : String -> ConcurrentTask String ProposalMetadata
     , retrieveTx : NetworkId -> Bytes TransactionId -> ConcurrentTask ConcurrentTask.Http.Error (Bytes Transaction)
@@ -101,6 +102,14 @@ protocolParamsDecoder =
 ogmiosEpochDecoder : Decoder Int
 ogmiosEpochDecoder =
     JD.field "result" JD.int
+
+
+{-| Decoder for the Cardano constitution URI from Ogmios.
+The constitution metadata contains a URL field that points to the constitution document.
+-}
+ogmiosConstitutionDecoder : Decoder String
+ogmiosConstitutionDecoder =
+    JD.at [ "result", "metadata", "url" ] JD.string
 
 
 
@@ -559,6 +568,25 @@ defaultApiProvider =
                             ]
                         )
                 , expect = Http.expectJson toMsg ogmiosEpochDecoder
+                , timeout = Nothing
+                , tracker = Nothing
+                }
+
+    -- Query constitution URI via Koios
+    , queryConstitution =
+        \networkId toMsg ->
+            Http.request
+                { method = "POST"
+                , url = koiosUrl networkId ++ "/ogmios"
+                , headers = [ Http.header "Authorization" <| "Bearer " ++ koiosApiToken ]
+                , body =
+                    Http.jsonBody
+                        (JE.object
+                            [ ( "jsonrpc", JE.string "2.0" )
+                            , ( "method", JE.string "queryLedgerState/constitution" )
+                            ]
+                        )
+                , expect = Http.expectJson toMsg ogmiosConstitutionDecoder
                 , timeout = Nothing
                 , tracker = Nothing
                 }

--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -2051,8 +2051,7 @@ referenceForm index typeName label uri deleteMsg typeChangeMsg labelChangeMsg ur
                     ]
                     [ text "Type" ]
                 , viewSelect
-                    [ HA.value typeName
-                    , Html.Events.onInput typeChangeMsg
+                    [ Html.Events.onInput typeChangeMsg
                     , HA.style "width" "100%"
                     , HA.style "padding" "0.5rem"
                     , HA.style "border" "1px solid #E2E8F0"
@@ -2060,9 +2059,9 @@ referenceForm index typeName label uri deleteMsg typeChangeMsg labelChangeMsg ur
                     , HA.style "font-size" "0.875rem"
                     , HA.style "background-color" "white"
                     ]
-                    [ Html.option [ HA.value "relevant articles" ] [ text "Relevant Articles" ]
-                    , Html.option [ HA.value "governance metadata" ] [ text "Governance Metadata" ]
-                    , Html.option [ HA.value "other" ] [ text "Other" ]
+                    [ Html.option [ HA.value "relevant articles", HA.selected (typeName == "relevant articles") ] [ text "Relevant Articles" ]
+                    , Html.option [ HA.value "governance metadata", HA.selected (typeName == "governance metadata") ] [ text "Governance Metadata" ]
+                    , Html.option [ HA.value "other", HA.selected (typeName == "other") ] [ text "Other" ]
                     ]
                 ]
             , div []

--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -1970,18 +1970,22 @@ voteNumberInput label value onInputMsg =
 
 {-| Card for references with add button in header
 -}
-referenceCard : List (Html msg) -> msg -> Maybe msg -> Html msg
-referenceCard content addMsg maybeConstitutionMsg =
+referenceCard : List (Html msg) -> msg -> Maybe msg -> Maybe msg -> Html msg
+referenceCard content addMsg maybeConstitutionMsg maybeProposalMetadataMsg =
     let
-        quickAddSection =
-            case maybeConstitutionMsg of
-                Just constitutionMsg ->
-                    div []
-                        [ blackSquareButton [] "+ Constitution" constitutionMsg
-                        ]
+        quickAddConstitution =
+            Maybe.map (blackSquareButton [] "+ Constitution") maybeConstitutionMsg
 
-                Nothing ->
+        quickAddProposalMetadata =
+            Maybe.map (blackSquareButton [] "+ Proposal Metadata") maybeProposalMetadataMsg
+
+        quickAddSection =
+            case List.filterMap identity [ quickAddConstitution, quickAddProposalMetadata ] of
+                [] ->
                     text ""
+
+                quickAddButtons ->
+                    div [ HA.style "display" "flex", HA.style "gap" "0.5rem" ] quickAddButtons
     in
     cardContainer []
         [ cardHeader []

--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -1970,19 +1970,35 @@ voteNumberInput label value onInputMsg =
 
 {-| Card for references with add button in header
 -}
-referenceCard : List (Html msg) -> msg -> Html msg
-referenceCard content addMsg =
+referenceCard : List (Html msg) -> msg -> Maybe msg -> Html msg
+referenceCard content addMsg maybeConstitutionMsg =
+    let
+        quickAddSection =
+            case maybeConstitutionMsg of
+                Just constitutionMsg ->
+                    div []
+                        [ blackSquareButton [] "+ Constitution" constitutionMsg
+                        ]
+
+                Nothing ->
+                    text ""
+    in
     cardContainer []
-        [ cardHeader
-            [ HA.style "display" "flex"
-            , HA.style "justify-content" "space-between"
-            , HA.style "align-items" "center"
-            ]
+        [ cardHeader []
             "References"
             "Add links and references to support your rationale."
-            [ blackSquareButton [] "+ Add Reference" addMsg ]
+            []
         , cardContent []
-            [ if List.isEmpty content then
+            [ div
+                [ HA.style "display" "flex"
+                , HA.style "justify-content" "space-between"
+                , HA.style "align-items" "center"
+                , HA.style "margin-bottom" "1rem"
+                , HA.style "padding-bottom" "1rem"
+                , HA.style "border-bottom" "1px solid #E2E8F0"
+                ]
+                [ quickAddSection, blackSquareButton [] "+ Add Reference" addMsg ]
+            , if List.isEmpty content then
                 Html.p
                     [ HA.style "text-align" "center"
                     , HA.style "color" "#6B7280"

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -181,6 +181,7 @@ type alias Model =
     , walletUtxos : Maybe (Utxo.RefDict Output)
     , walletDrepId : Maybe (Bytes CredentialHash)
     , protocolParams : Maybe ProtocolParams
+    , constitutionUri : Maybe String
     , epoch : WebData Int
     , proposals : WebData (Dict String ActiveProposal)
     , scriptsInfo : Dict String ScriptInfo
@@ -262,6 +263,7 @@ initHelper route config =
     , Cmd.batch
         [ cmd
         , Api.defaultApiProvider.loadProtocolParams model.networkId GotProtocolParams
+        , Api.defaultApiProvider.queryConstitution model.networkId GotConstitution
         , Cmd.batch tasksCmds
         ]
     )
@@ -290,6 +292,7 @@ initialModel { jsonLdContexts, db, networkId, ipfsPreconfig, voterPreconfig, aut
     , walletUtxos = Nothing
     , walletDrepId = Nothing
     , protocolParams = Nothing
+    , constitutionUri = Nothing
     , epoch = RemoteData.NotAsked
     , proposals = RemoteData.NotAsked
     , scriptsInfo = Dict.empty
@@ -319,6 +322,7 @@ type Msg
     | UrlChanged Route
     | WalletMsg Value
     | GotProtocolParams (Result Http.Error ProtocolParams)
+    | GotConstitution (Result Http.Error String)
     | GotEpoch (Result Http.Error Int)
     | GotProposals (Result Http.Error (List ActiveProposal))
       -- Header
@@ -594,6 +598,14 @@ update msg model =
                 Err err ->
                     ( { model | errors = Debug.toString err :: model.errors }, Cmd.none )
 
+        ( GotConstitution result, _ ) ->
+            case result of
+                Ok uri ->
+                    ( { model | constitutionUri = Just uri }, Cmd.none )
+
+                Err err ->
+                    ( { model | errors = Debug.toString err :: model.errors }, Cmd.none )
+
         ( WalletMsg value, _ ) ->
             case JD.decodeValue walletResponseDecoder value of
                 Ok response ->
@@ -630,6 +642,7 @@ update msg model =
                             , jsonRationaleToFile = jsonRationaleToFile
                             , pdfBytesToFile = pdfBytesToFile
                             , costModels = Maybe.map .costModels model.protocolParams
+                            , constitutionUri = model.constitutionUri
                             , networkId = model.networkId
                             , authorPreconfig = model.authorPreconfig
                             }
@@ -1555,6 +1568,7 @@ viewContent model =
                 , proposals = model.proposals
                 , jsonLdContexts = model.jsonLdContexts
                 , costModels = Maybe.map .costModels model.protocolParams
+                , constitutionUri = model.constitutionUri
                 , networkId = model.networkId
                 , changeNetworkLink =
                     \networkId ->

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -717,6 +717,7 @@ type Msg
     | InternalAgainstVoteChange String
     | AddRefButtonClicked
     | AddConstitutionRefButtonClicked
+    | AddProposalMetadataRefsButtonClicked String String
     | DeleteRefButtonClicked Int
     | ReferenceLabelChange Int String
     | ReferenceUriChange Int String
@@ -1231,6 +1232,25 @@ innerUpdate ctx msg model =
                     }
             in
             ( updateRationaleForm (\form -> { form | references = form.references ++ [ constitutionRef ] }) model
+            , Cmd.none
+            , Nothing
+            )
+
+        AddProposalMetadataRefsButtonClicked metadataUrl metadataHash ->
+            let
+                urlRef =
+                    { type_ = GovernanceMetadataRefType
+                    , label = "Proposal Metadata Anchor URI"
+                    , uri = metadataUrl
+                    }
+
+                hashRef =
+                    { type_ = GovernanceMetadataRefType
+                    , label = "Proposal Metadata Anchor Hash"
+                    , uri = metadataHash
+                    }
+            in
+            ( updateRationaleForm (\form -> { form | references = form.references ++ [ urlRef, hashRef ] }) model
             , Cmd.none
             , Nothing
             )
@@ -4445,8 +4465,8 @@ viewRationaleStep ctx pickProposalStep storageConfigStep step =
                     , Helper.stepNotAvailableCard [ text description ]
                     ]
 
-            ( Done _ _, Done _ storageConfig, Preparing form ) ->
-                viewRationaleForm ctx { hostingIsAppControlled = isHostingAppControlled storageConfig } form
+            ( Done _ proposal, Done _ storageConfig, Preparing form ) ->
+                viewRationaleForm ctx proposal { hostingIsAppControlled = isHostingAppControlled storageConfig } form
 
             ( Done _ _, Done _ _, Validating _ _ ) ->
                 div []
@@ -4498,8 +4518,8 @@ isHostingAppControlled storageConfig =
             False
 
 
-viewRationaleForm : ViewContext msg -> { hostingIsAppControlled : Bool } -> RationaleForm -> Html Msg
-viewRationaleForm ctx { hostingIsAppControlled } form =
+viewRationaleForm : ViewContext msg -> ActiveProposal -> { hostingIsAppControlled : Bool } -> RationaleForm -> Html Msg
+viewRationaleForm ctx proposal { hostingIsAppControlled } form =
     div []
         [ Helper.sectionTitle "Vote Rationale"
         , div [ HA.style "display" "grid", HA.style "gap" "1.5rem", HA.style "position" "relative" ]
@@ -4537,6 +4557,7 @@ viewRationaleForm ctx { hostingIsAppControlled } form =
                         (List.indexedMap viewOneRefForm form.references)
                         AddRefButtonClicked
                         (Maybe.map (\_ -> AddConstitutionRefButtonClicked) ctx.constitutionUri)
+                        (Just (AddProposalMetadataRefsButtonClicked proposal.metadataUrl proposal.metadataHash))
                     ]
 
               else

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -716,6 +716,7 @@ type Msg
     | InternalDidNotVoteChange String
     | InternalAgainstVoteChange String
     | AddRefButtonClicked
+    | AddConstitutionRefButtonClicked
     | DeleteRefButtonClicked Int
     | ReferenceLabelChange Int String
     | ReferenceUriChange Int String
@@ -773,6 +774,7 @@ type alias UpdateContext msg =
     , jsonRationaleToFile : { fileContent : String, fileName : String } -> Cmd msg
     , pdfBytesToFile : { fileContentHex : String, fileName : String } -> Cmd msg
     , costModels : Maybe CostModels
+    , constitutionUri : Maybe String
     , networkId : NetworkId
     , authorPreconfig : List PreconfAuthor
     }
@@ -1216,6 +1218,19 @@ innerUpdate ctx msg model =
 
         AddRefButtonClicked ->
             ( updateRationaleForm (\form -> { form | references = form.references ++ [ initRefForm ] }) model
+            , Cmd.none
+            , Nothing
+            )
+
+        AddConstitutionRefButtonClicked ->
+            let
+                constitutionRef =
+                    { type_ = RelevantArticlesRefType
+                    , label = "Cardano Constitution"
+                    , uri = Maybe.withDefault "" ctx.constitutionUri
+                    }
+            in
+            ( updateRationaleForm (\form -> { form | references = form.references ++ [ constitutionRef ] }) model
             , Cmd.none
             , Nothing
             )
@@ -3146,6 +3161,7 @@ type alias ViewContext msg =
     , proposals : WebData (Dict String ActiveProposal)
     , jsonLdContexts : JsonLdContexts
     , costModels : Maybe CostModels
+    , constitutionUri : Maybe String
     , networkId : NetworkId
     , changeNetworkLink : NetworkId -> List (Html msg) -> Html msg
     , signingLink : Transaction -> List { keyName : String, keyHash : Bytes CredentialHash } -> List (Html msg) -> Html msg
@@ -4430,7 +4446,7 @@ viewRationaleStep ctx pickProposalStep storageConfigStep step =
                     ]
 
             ( Done _ _, Done _ storageConfig, Preparing form ) ->
-                viewRationaleForm { hostingIsAppControlled = isHostingAppControlled storageConfig } form
+                viewRationaleForm ctx { hostingIsAppControlled = isHostingAppControlled storageConfig } form
 
             ( Done _ _, Done _ _, Validating _ _ ) ->
                 div []
@@ -4482,8 +4498,8 @@ isHostingAppControlled storageConfig =
             False
 
 
-viewRationaleForm : { hostingIsAppControlled : Bool } -> RationaleForm -> Html Msg
-viewRationaleForm { hostingIsAppControlled } form =
+viewRationaleForm : ViewContext msg -> { hostingIsAppControlled : Bool } -> RationaleForm -> Html Msg
+viewRationaleForm ctx { hostingIsAppControlled } form =
     div []
         [ Helper.sectionTitle "Vote Rationale"
         , div [ HA.style "display" "grid", HA.style "gap" "1.5rem", HA.style "position" "relative" ]
@@ -4520,6 +4536,7 @@ viewRationaleForm { hostingIsAppControlled } form =
                     , Helper.referenceCard
                         (List.indexedMap viewOneRefForm form.references)
                         AddRefButtonClicked
+                        (Maybe.map (\_ -> AddConstitutionRefButtonClicked) ctx.constitutionUri)
                     ]
 
               else


### PR DESCRIPTION
This adds 2 buttons in the "References" section of the rationale creation step:
- One button shortcut to add a reference to the current constitution document.
- One button shortcut to add references (URI + hash) to the currently reviewed proposal metadata.

Solves issue #126 

<img width="859" height="806" alt="image" src="https://github.com/user-attachments/assets/49bde30f-7c0f-4d1b-b9b4-57d82b4510d3" />
