### PR TITLE
Fix error messages with coin selection when there is not enough ada

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -61,6 +61,7 @@ import Cmd.Extra
 import ConcurrentTask exposing (ConcurrentTask)
 import ConcurrentTask.Extra
 import Dict exposing (Dict)
+import Dict.Any
 import Footer
 import Header
 import Helper exposing (PreconfAuthor, PreconfVoter)
@@ -71,6 +72,7 @@ import Http
 import Json.Decode as JD exposing (Decoder, Value)
 import Json.Encode as JE
 import List.Extra
+import Natural as N
 import Page.Cart
 import Page.Disclaimer
 import Page.MultisigRegistration
@@ -1136,9 +1138,31 @@ handleWalletResponse response model =
 
         -- We just received the utxos
         Cip30.ApiResponse _ (Cip30ApiResponse (Cip30.WalletUtxos utxos)) ->
-            ( { model | walletUtxos = Just (Utxo.refDictFromList utxos) }
-            , Cmd.none
-            )
+            case model.wallet of
+                Nothing ->
+                    -- This should never happen in practice
+                    ( model, Cmd.none )
+
+                Just wallet ->
+                    ( { model | walletUtxos = Just (Utxo.refDictFromList utxos) }
+                      -- Also ask for collateral UTxOs after receiving the normal UTxOs
+                    , Cip30.getCollateral wallet { amount = N.fromSafeInt 1000000 }
+                        |> Cip30.encodeRequest
+                        |> toWallet
+                    )
+
+        -- We just received the collateral utxos
+        Cip30.ApiResponse _ (Cip30ApiResponse (Cip30.Collateral collateralUtxos)) ->
+            case model.walletUtxos of
+                Nothing ->
+                    ( { model | walletUtxos = Just (Utxo.refDictFromList collateralUtxos) }
+                    , Cmd.none
+                    )
+
+                Just utxos ->
+                    ( { model | walletUtxos = Just <| Dict.Any.union utxos (Utxo.refDictFromList collateralUtxos) }
+                    , Cmd.none
+                    )
 
         -- We just received the DRep ID of the wallet
         Cip30.ApiResponse _ (Cip95ApiResponse (Cip95.DrepKey drepKey)) ->

--- a/frontend/src/Page/Cart.elm
+++ b/frontend/src/Page/Cart.elm
@@ -5,7 +5,6 @@ import Cardano.Address as Address exposing (Address, CredentialHash)
 import Cardano.Cip30 as Cip30
 import Cardano.CoinSelection as CoinSelection
 import Cardano.Gov as Gov exposing (ActionId, Anchor, CostModels, Id(..))
-import Cardano.MultiAsset as MultiAsset
 import Cardano.Script as Script
 import Cardano.Transaction as Transaction exposing (Transaction)
 import Cardano.TxIntent as TxIntent exposing (Fee(..), TxFinalizationError(..), TxFinalized, TxIntent, VoteIntent)

--- a/frontend/src/Page/Cart.elm
+++ b/frontend/src/Page/Cart.elm
@@ -5,9 +5,10 @@ import Cardano.Address as Address exposing (Address, CredentialHash)
 import Cardano.Cip30 as Cip30
 import Cardano.CoinSelection as CoinSelection
 import Cardano.Gov as Gov exposing (ActionId, Anchor, CostModels, Id(..))
+import Cardano.MultiAsset as MultiAsset
 import Cardano.Script as Script
 import Cardano.Transaction as Transaction exposing (Transaction)
-import Cardano.TxIntent as TxIntent exposing (Fee(..), TxFinalized, TxIntent, VoteIntent)
+import Cardano.TxIntent as TxIntent exposing (Fee(..), TxFinalizationError(..), TxFinalized, TxIntent, VoteIntent)
 import Cardano.Uplc as Uplc
 import Cardano.Utils as Utils
 import Cardano.Utxo as Utxo exposing (Output)
@@ -718,7 +719,20 @@ buildTx costModels localStateUtxos walletAddress votersIntents =
             (AutoFee { paymentSource = feeSource })
             []
         |> Result.map (\txFinalized -> { keyNames = keyNames, txFinalized = txFinalized })
-        |> Result.mapError TxIntent.errorToString
+        |> Result.mapError customTxBuildingError
+
+
+customTxBuildingError : TxFinalizationError -> String
+customTxBuildingError error =
+    case error of
+        FailedToPerformCoinSelection CoinSelection.MaximumInputCountExceeded ->
+            "Your wallet has too many small inputs. An easy fix is doing a transfer to yourself of at least 2 ADA. This will create a new UTxO with at least 2 ADA in it."
+
+        FailedToPerformCoinSelection (CoinSelection.UTxOBalanceInsufficient _) ->
+            "You don’t have enough ada in your wallet to pay for the Tx fees. We have two solutions here!\n\n1. Simply send some ada to your wallet, then refresh the page.\n\n2. Or you can change the connected wallet to another one with enough ada to pay for the Tx fees. No worry, your votes will not change. In the signing page, you’ll simply need to connect and sign with both the DRep wallet and the wallet paying the fees."
+
+        _ ->
+            TxIntent.errorToString error
 
 
 


### PR DESCRIPTION
This fixes the following 2 situations in the application:

1. Not enough ada in the wallet to pay the fees
2. Hidden UTxOs marked as "collateral" by the wallet now visible

(1) Will now display a clear error message
(2) Solves situations where the wallet would hide a UTxO if it’s the only one "pure ada" UTxO.

For reference, here is the old error message:

```
Error while performing coin selection: UTxO balance insufficient. I am still missing the following value, from the following UTxOs.

Still missing value: ₳ 1000000

Selected UTxOs (with the value they contains):
```

And new error message:

```
You don’t have enough ada in your wallet to pay for the Tx fees. We have two solutions here!

1. Simply send some ada to your wallet, then refresh the page.

2. Or you can change the connected wallet to another one with enough ada to pay for the Tx fees. No worry, your votes will not change. In the signing page, you’ll simply need to connect and sign with both the DRep wallet and the wallet paying the fees.
```