### PR TITLE
Keep Tx signatures in url

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -1183,6 +1183,13 @@ handleWalletResponse response model =
                 , walletUtxos = Nothing
                 , lastConnectedWalletId = Just (Cip30.walletDescriptor wallet).id
                 , taskPool = updatedTaskPool
+                , page =
+                    case model.page of
+                        SigningPage pageModel ->
+                            SigningPage (Page.Signing.clearError pageModel)
+
+                        other ->
+                            other
               }
             , Cmd.batch
                 -- Retrieve UTXOs from the main wallet

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -717,9 +717,15 @@ update msg model =
                             , walletSignTx = walletSignTx
                             , walletSubmitTx = walletSubmitTx
                             }
+
+                        ( newModel, pageCmds ) =
+                            Page.Signing.update ctx pageMsg pageModel
+                                |> Tuple.mapFirst (\newPageModel -> { model | page = SigningPage newPageModel })
+
+                        ( finalModel, urlCmd ) =
+                            updateSigningPageUrl newModel
                     in
-                    Page.Signing.update ctx pageMsg pageModel
-                        |> Tuple.mapFirst (\newPageModel -> { model | page = SigningPage newPageModel })
+                    ( finalModel, Cmd.batch [ pageCmds, urlCmd ] )
 
                 _ ->
                     ( model, Cmd.none )
@@ -1236,9 +1242,11 @@ handleWalletResponse response model =
         Cip30.ApiResponse _ (Cip30ApiResponse (Cip30.SignedTx vkeyWitnesses)) ->
             case model.page of
                 SigningPage pageModel ->
-                    ( { model | page = SigningPage <| Page.Signing.addWalletSignatures vkeyWitnesses pageModel }
-                    , Cmd.none
-                    )
+                    let
+                        updatedModel =
+                            { model | page = SigningPage <| Page.Signing.addWalletSignatures vkeyWitnesses pageModel }
+                    in
+                    updateSigningPageUrl updatedModel
 
                 -- No other page expects to receive a Tx signature
                 _ ->
@@ -1409,6 +1417,37 @@ saveCart cart model =
     ConcurrentTask.attempt { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete } writeCartToDb
         |> Tuple.mapFirst (\newTaskPool -> { model | taskPool = newTaskPool, cart = cart })
         |> Cmd.Extra.add (broadcastCart model.networkId cart)
+
+
+{-| Update the URL fragment to include the latest gathered signatures.
+Called after wallet signing or file upload adds new signatures.
+-}
+updateSigningPageUrl : Model -> ( Model, Cmd Msg )
+updateSigningPageUrl model =
+    case model.page of
+        SigningPage pageModel ->
+            case Page.Signing.getSignedTx pageModel of
+                Just signedTx ->
+                    let
+                        newAppUrl =
+                            { path = model.appUrl.path
+                            , queryParameters = model.appUrl.queryParameters
+                            , fragment = Just (Bytes.toHex (Transaction.serialize signedTx))
+                            }
+                    in
+                    if newAppUrl == model.appUrl then
+                        ( model, Cmd.none )
+
+                    else
+                        ( { model | appUrl = newAppUrl }
+                        , pushUrl (AppUrl.toString newAppUrl)
+                        )
+
+                Nothing ->
+                    ( model, Cmd.none )
+
+        _ ->
+            ( model, Cmd.none )
 
 
 {-| Helper function to reset the signing step of the Preparation.

--- a/frontend/src/Page/Signing.elm
+++ b/frontend/src/Page/Signing.elm
@@ -1,4 +1,4 @@
-module Page.Signing exposing (Model, Msg, UpdateContext, ViewContext, addWalletSignatures, getTxInfo, initialModel, recordSubmittedTx, resetSubmission, update, view)
+module Page.Signing exposing (Model, Msg, UpdateContext, ViewContext, addWalletSignatures, getSignedTx, getTxInfo, initialModel, recordSubmittedTx, resetSubmission, update, view)
 
 {-| This module handles the signing process for Cardano transactions, particularly
 focusing on complex scenarios like Native or Plutus script multi-signatures.
@@ -65,14 +65,24 @@ initialModel : List { keyName : String, keyHash : Bytes CredentialHash } -> Mayb
 initialModel expectedSigners maybeTx =
     case maybeTx of
         Just tx ->
-            LoadedTx
-                { tx = tx
-                , txId = Transaction.computeTxId tx
-                , expectedSigners =
+            let
+                expectedSignersDict =
                     expectedSigners
                         |> List.map (\{ keyName, keyHash } -> ( Bytes.toHex keyHash, { keyName = keyName, keyHash = keyHash } ))
                         |> Dict.fromList
-                , vkeyWitnesses = Dict.empty
+
+                existingWitnesses =
+                    tx.witnessSet.vkeywitness
+                        |> Maybe.withDefault []
+                        |> List.filter (\w -> Dict.member (Bytes.toHex (Transaction.hashVKey w.vkey)) expectedSignersDict)
+                        |> List.map (\w -> ( Bytes.toHex (Transaction.hashVKey w.vkey), w ))
+                        |> Dict.fromList
+            in
+            LoadedTx
+                { tx = tx
+                , txId = Transaction.computeTxId tx
+                , expectedSigners = expectedSignersDict
+                , vkeyWitnesses = existingWitnesses
                 , txSubmitted = Nothing
                 , error = Nothing
                 }
@@ -88,6 +98,23 @@ getTxInfo model =
             Just { tx = loadedTxModel.tx, txId = loadedTxModel.txId }
 
         _ ->
+            Nothing
+
+
+{-| Returns the Tx with currently gathered vkeyWitnesses baked in.
+Returns the original Tx unchanged if no signatures have been gathered.
+-}
+getSignedTx : Model -> Maybe Transaction
+getSignedTx model =
+    case model of
+        LoadedTx { tx, vkeyWitnesses } ->
+            if Dict.isEmpty vkeyWitnesses then
+                Just tx
+
+            else
+                Just (Transaction.updateSignatures (\_ -> Just (Dict.values vkeyWitnesses)) tx)
+
+        MissingTx ->
             Nothing
 
 

--- a/frontend/src/Page/Signing.elm
+++ b/frontend/src/Page/Signing.elm
@@ -1,4 +1,4 @@
-module Page.Signing exposing (Model, Msg, UpdateContext, ViewContext, addWalletSignatures, getSignedTx, getTxInfo, initialModel, recordSubmittedTx, resetSubmission, update, view)
+module Page.Signing exposing (Model, Msg, UpdateContext, ViewContext, addWalletSignatures, clearError, getSignedTx, getTxInfo, initialModel, recordSubmittedTx, resetSubmission, update, view)
 
 {-| This module handles the signing process for Cardano transactions, particularly
 focusing on complex scenarios like Native or Plutus script multi-signatures.
@@ -181,14 +181,21 @@ update ctx msg model =
         ( LoadedSignedTxJson _, _ ) ->
             ( model, Cmd.none )
 
-        ( SubmitTxButtonClicked, LoadedTx { tx, vkeyWitnesses } ) ->
-            let
-                signedTx =
-                    Transaction.updateSignatures (\_ -> Just <| Dict.values vkeyWitnesses) tx
-            in
-            ( model
-            , ctx.walletSubmitTx signedTx
-            )
+        ( SubmitTxButtonClicked, LoadedTx loadedTxModel ) ->
+            case ctx.wallet of
+                Nothing ->
+                    ( LoadedTx { loadedTxModel | error = Just "Please connect a wallet to submit the transaction via the CIP-30 wallet API." }
+                    , Cmd.none
+                    )
+
+                Just _ ->
+                    let
+                        signedTx =
+                            Transaction.updateSignatures (\_ -> Just <| Dict.values loadedTxModel.vkeyWitnesses) loadedTxModel.tx
+                    in
+                    ( LoadedTx { loadedTxModel | error = Nothing }
+                    , ctx.walletSubmitTx signedTx
+                    )
 
         ( SubmitTxButtonClicked, _ ) ->
             ( model, Cmd.none )
@@ -280,6 +287,16 @@ addWalletSignatures newVkeyWitnesses model =
 
         _ ->
             model
+
+
+clearError : Model -> Model
+clearError model =
+    case model of
+        LoadedTx loadedTxModel ->
+            LoadedTx { loadedTxModel | error = Nothing }
+
+        MissingTx ->
+            MissingTx
 
 
 recordSubmittedTx : Bytes TransactionId -> Model -> Model


### PR DESCRIPTION
This change enables also keeping the signature witnesses of the Tx in the fragment part of the url (the part after the #). This is very convenient when you want to share a pre-signed Tx with another person so that they just have to add their signature to submit the Tx.