### PR TITLE
Display badges for competing proposals

### DIFF
--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -1,4 +1,4 @@
-module Api exposing (ActiveProposal, ApiProvider, AuthorVerification, CcInfo, Cip100VerificationResponse, DrepInfo, IpfsAnswer(..), IpfsFile, OnchainVote, PoolInfo, ProtocolParams, defaultApiProvider, taskFetchFromUrl, taskGetDatumInfo, taskGetUtxoInfo)
+module Api exposing (ActiveProposal, ApiProvider, AuthorVerification, CcInfo, Cip100VerificationResponse, DrepInfo, IpfsAnswer(..), IpfsFile, OnchainVote, PoolInfo, ProtocolParams, defaultApiProvider, taskFetchFromUrl, taskGetDatumInfo, taskGetUtxoInfo, taskRetrieveTxBatch)
 
 {-| Module gathering all the remote HTTP calls made by the app.
 -}
@@ -13,6 +13,7 @@ import Cardano.Utxo exposing (TransactionId)
 import ConcurrentTask exposing (ConcurrentTask)
 import ConcurrentTask.Http
 import ConcurrentTask.Process
+import Dict exposing (Dict)
 import File exposing (File)
 import Helper
 import Http
@@ -1058,6 +1059,45 @@ taskRetrieveTx networkId txId =
                     ]
                 )
         , expect = ConcurrentTask.Http.expectJson thisTxDecoder
+        , timeout = Nothing
+        }
+
+
+{-| Task to retrieve the raw CBOR of multiple Txs in a single Koios request.
+Returns a Dict keyed by tx hash hex string.
+-}
+taskRetrieveTxBatch : NetworkId -> List (Bytes TransactionId) -> ConcurrentTask ConcurrentTask.Http.Error (Dict String (Bytes a))
+taskRetrieveTxBatch networkId txIds =
+    let
+        batchDecoder : Decoder (Dict String (Bytes a))
+        batchDecoder =
+            JD.list
+                (JD.map2 (\txId cbor -> ( Bytes.toHex txId, cbor ))
+                    (JD.field "tx_hash" Bytes.jsonDecoder)
+                    (JD.field "cbor" Bytes.jsonDecoder)
+                )
+                |> JD.map Dict.fromList
+
+        koiosUrl =
+            case networkId of
+                Testnet ->
+                    "https://preview.koios.rest/api/v1"
+
+                Mainnet ->
+                    "https://api.koios.rest/api/v1"
+    in
+    ConcurrentTask.Http.post
+        { url = "/proxy/json"
+        , headers = []
+        , body =
+            ConcurrentTask.Http.jsonBody
+                (JE.object
+                    [ ( "url", JE.string <| koiosUrl ++ "/tx_cbor" )
+                    , ( "method", JE.string "POST" )
+                    , ( "body", JE.object [ ( "_tx_hashes", JE.list (JE.string << Bytes.toHex) txIds ) ] )
+                    ]
+                )
+        , expect = ConcurrentTask.Http.expectJson batchDecoder
         , timeout = Nothing
         }
 

--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -1640,7 +1640,7 @@ viewRelBadges relInfo =
 
         Just info ->
             let
-                smallBadge bgColor color label =
+                smallBadge bgColor color tooltip label =
                     Html.span
                         [ HA.style "display" "inline-flex"
                         , HA.style "align-items" "center"
@@ -1650,13 +1650,15 @@ viewRelBadges relInfo =
                         , HA.style "padding" "0.125rem 0.4rem"
                         , HA.style "border-radius" "0.375rem"
                         , HA.style "font-size" "0.75rem"
+                        , HA.style "cursor" "help"
+                        , HA.title tooltip
                         ]
                         [ text label ]
             in
-            smallBadge "#E2E8F0" "#4A5568" ("#" ++ String.fromInt info.number)
+            smallBadge "#E2E8F0" "#4A5568" "Proposal number for cross-referencing related proposals" ("#" ++ String.fromInt info.number)
                 :: (case info.follows of
                         Just n ->
-                            [ smallBadge "#FEF3C7" "#D97706" ("Follows #" ++ String.fromInt n) ]
+                            [ smallBadge "#FEF3C7" "#D97706" ("This proposal depends on #" ++ String.fromInt n ++ " being enacted first") ("Follows #" ++ String.fromInt n) ]
 
                         Nothing ->
                             []
@@ -1665,10 +1667,10 @@ viewRelBadges relInfo =
                         []
 
                     else
-                        [ smallBadge "#FEE2E2" "#DC2626" ("Competing #" ++ String.join ", #" (List.map String.fromInt info.competingWith)) ]
+                        [ smallBadge "#FEE2E2" "#DC2626" "These proposals share the same purpose and parent action, so only one can be enacted" ("Competing #" ++ String.join ", #" (List.map String.fromInt info.competingWith)) ]
                    )
                 ++ (if info.isDelaying then
-                        [ smallBadge "#EDE9FE" "#7C3AED" "Delaying" ]
+                        [ smallBadge "#EDE9FE" "#7C3AED" "If ratified, this action delays all other ratifications for the rest of the epoch" "Delaying" ]
 
                     else
                         []

--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -1320,8 +1320,8 @@ showMoreButton hasMore visibleCount totalCount clickMsg =
 
 {-| Card for an individual proposal
 -}
-proposalCard : { title : String, hashIsValid : Bool, pastVote : Maybe Gov.Vote, isRatifying : Bool, isLastEpoch : Bool, expiryText : String, abstract : String, actionType : String, linkUrl : String, linkHex : String, index : Int } -> msg -> Html msg -> Html msg
-proposalCard { title, hashIsValid, pastVote, isRatifying, isLastEpoch, expiryText, abstract, actionType, linkUrl, linkHex, index } selectMsg actionIcon =
+proposalCard : { title : String, hashIsValid : Bool, pastVote : Maybe Gov.Vote, isRatifying : Bool, isLastEpoch : Bool, expiryText : String, abstract : String, actionType : String, linkUrl : String, linkHex : String, index : Int, relInfo : Maybe { number : Int, follows : Maybe Int, competingWith : List Int, isDelaying : Bool } } -> msg -> Html msg -> Html msg
+proposalCard { title, hashIsValid, pastVote, isRatifying, isLastEpoch, expiryText, abstract, actionType, linkUrl, linkHex, index, relInfo } selectMsg actionIcon =
     div
         [ HA.style "border" "1px solid #E2E8F0"
         , HA.style "border-radius" "0.75rem"
@@ -1393,12 +1393,13 @@ proposalCard { title, hashIsValid, pastVote, isRatifying, isLastEpoch, expiryTex
 
                 badges : List (Html msg)
                 badges =
-                    (if hashIsValid then
-                        []
+                    viewRelBadges relInfo
+                        ++ (if hashIsValid then
+                                []
 
-                     else
-                        [ invalidHashBadge ]
-                    )
+                            else
+                                [ invalidHashBadge ]
+                           )
                         ++ (if isRatifying then
                                 [ ratifyingBadge ]
 
@@ -1628,9 +1629,55 @@ viewPastVoteBadge vote =
         [ text label ]
 
 
+{-| Render relationship badges (number, follows, competing, delaying) for a proposal.
+Reusable across proposal cards, cart rows, etc.
+-}
+viewRelBadges : Maybe { number : Int, follows : Maybe Int, competingWith : List Int, isDelaying : Bool } -> List (Html msg)
+viewRelBadges relInfo =
+    case relInfo of
+        Nothing ->
+            []
+
+        Just info ->
+            let
+                smallBadge bgColor color label =
+                    Html.span
+                        [ HA.style "display" "inline-flex"
+                        , HA.style "align-items" "center"
+                        , HA.style "background-color" bgColor
+                        , HA.style "color" color
+                        , HA.style "font-weight" "600"
+                        , HA.style "padding" "0.125rem 0.4rem"
+                        , HA.style "border-radius" "0.375rem"
+                        , HA.style "font-size" "0.75rem"
+                        ]
+                        [ text label ]
+            in
+            smallBadge "#E2E8F0" "#4A5568" ("#" ++ String.fromInt info.number)
+                :: (case info.follows of
+                        Just n ->
+                            [ smallBadge "#FEF3C7" "#D97706" ("Follows #" ++ String.fromInt n) ]
+
+                        Nothing ->
+                            []
+                   )
+                ++ (if List.isEmpty info.competingWith then
+                        []
+
+                    else
+                        [ smallBadge "#FEE2E2" "#DC2626" ("Competing #" ++ String.join ", #" (List.map String.fromInt info.competingWith)) ]
+                   )
+                ++ (if info.isDelaying then
+                        [ smallBadge "#EDE9FE" "#7C3AED" "Delaying" ]
+
+                    else
+                        []
+                   )
+
+
 {-| List of proposals already in the cart for the currently selected voter.
 -}
-viewProposalsListInCart : List { proposalTitle : String, voteIntent : VoteIntent } -> Html msg
+viewProposalsListInCart : List { proposalTitle : String, voteIntent : VoteIntent, relInfo : Maybe { number : Int, follows : Maybe Int, competingWith : List Int, isDelaying : Bool } } -> Html msg
 viewProposalsListInCart items =
     if List.isEmpty items then
         text ""
@@ -1650,8 +1697,8 @@ viewProposalsListInCart items =
             ]
 
 
-viewProposalRowAt : Int -> { proposalTitle : String, voteIntent : VoteIntent } -> Html msg
-viewProposalRowAt index { proposalTitle, voteIntent } =
+viewProposalRowAt : Int -> { proposalTitle : String, voteIntent : VoteIntent, relInfo : Maybe { number : Int, follows : Maybe Int, competingWith : List Int, isDelaying : Bool } } -> Html msg
+viewProposalRowAt index { proposalTitle, voteIntent, relInfo } =
     Html.li
         [ HA.style "display" "flex"
         , HA.style "justify-content" "space-between"
@@ -1678,7 +1725,22 @@ viewProposalRowAt index { proposalTitle, voteIntent } =
                 , HA.style "overflow-wrap" "break-word"
                 , HA.style "word-break" "break-word"
                 ]
-                [ text proposalTitle ]
+                (text proposalTitle
+                    :: (case viewRelBadges relInfo of
+                            [] ->
+                                []
+
+                            badges ->
+                                [ Html.span
+                                    [ HA.style "display" "inline-flex"
+                                    , HA.style "gap" "0.25rem"
+                                    , HA.style "margin-left" "0.5rem"
+                                    , HA.style "vertical-align" "middle"
+                                    ]
+                                    badges
+                                ]
+                       )
+                )
             ]
         , viewDecisionBadge voteIntent.vote
         ]

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -1812,7 +1812,6 @@ recomputeProposalRelationships proposalsData govActions =
 
 
 
-
 -- #########################################################
 -- VIEW
 -- #########################################################
@@ -1960,7 +1959,6 @@ viewContent model =
 
                         _ ->
                             Nothing
-
             in
             Page.Preparation.view
                 { wrapMsg = PreparationPageMsg

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -82,6 +82,7 @@ import Page.Preparation exposing (JsonLdContexts, StorageConfig)
 import Page.Signing
 import Platform.Cmd as Cmd
 import ProposalMetadata exposing (ProposalMetadata)
+import ProposalRelationships exposing (ProposalRelInfo, isChainableAction)
 import RemoteData exposing (WebData)
 import ScriptInfo exposing (ScriptInfo)
 import Storage
@@ -187,6 +188,9 @@ type alias Model =
     , constitutionUri : Maybe String
     , epoch : WebData Int
     , proposals : WebData (Dict String ActiveProposal)
+    , pendingProposalId : Maybe String
+    , proposalRelationships : Dict String ProposalRelInfo
+    , proposalGovActions : Dict String Gov.Action
     , scriptsInfo : Dict String ScriptInfo
     , drepsInfo : Dict String DrepInfo
     , ccsInfo : Dict String CcInfo
@@ -200,7 +204,6 @@ type alias Model =
     , authorPreconfig : List PreconfAuthor
     , cart : Page.Cart.Model
     , errors : List String
-    , pendingProposalId : Maybe String
     }
 
 
@@ -222,6 +225,7 @@ type TaskCompleted
     | GotProposalMetadataTask String (Result String ProposalMetadata)
     | GotCart Page.Cart.Model
     | GotHlabsIncentive Page.Cart.HlabsIncentive
+    | GotProposalGovActions (Result String (Dict String Gov.Action))
     | PreparationTaskCompleted Page.Preparation.TaskCompleted
 
 
@@ -300,6 +304,9 @@ initialModel { jsonLdContexts, db, networkId, ipfsPreconfig, voterPreconfig, aut
     , constitutionUri = Nothing
     , epoch = RemoteData.NotAsked
     , proposals = RemoteData.NotAsked
+    , pendingProposalId = Nothing
+    , proposalRelationships = Dict.empty
+    , proposalGovActions = Dict.empty
     , scriptsInfo = Dict.empty
     , drepsInfo = Dict.empty
     , ccsInfo = Dict.empty
@@ -313,7 +320,6 @@ initialModel { jsonLdContexts, db, networkId, ipfsPreconfig, voterPreconfig, aut
     , authorPreconfig = authorPreconfig
     , cart = Page.Cart.init
     , errors = []
-    , pendingProposalId = Nothing
     }
 
 
@@ -898,9 +904,52 @@ update msg model =
                                 |> ConcurrentTask.toResult
                                 |> ConcurrentTask.map (GotProposalMetadataTask <| Helper.actionIdToBech32 id)
 
+                        -- Fetch tx CBORs for chainable proposals to extract latestEnacted
+                        chainableProposals =
+                            List.filter (\( _, p ) -> isChainableAction p.actionType) proposalsList
+
+                        -- Deduplicate tx hashes (multiple proposals can be in the same tx)
+                        uniqueTxIds =
+                            chainableProposals
+                                |> List.map (\( _, p ) -> p.id.transactionId)
+                                |> List.Extra.uniqueBy Bytes.toHex
+
+                        fetchGovActionsTask : ConcurrentTask x TaskCompleted
+                        fetchGovActionsTask =
+                            Api.taskRetrieveTxBatch model.networkId uniqueTxIds
+                                |> ConcurrentTask.map
+                                    (\txCborDict ->
+                                        let
+                                            extractAction ( bech32Id, proposal ) =
+                                                Dict.get (Bytes.toHex proposal.id.transactionId) txCborDict
+                                                    |> Maybe.andThen Transaction.deserialize
+                                                    |> Maybe.andThen (\tx -> List.Extra.getAt proposal.id.govActionIndex tx.body.proposalProcedures)
+                                                    |> Maybe.map (\procedure -> ( bech32Id, procedure.govAction ))
+
+                                            govActions =
+                                                List.filterMap extractAction chainableProposals
+                                                    |> Dict.fromList
+                                        in
+                                        GotProposalGovActions (Ok govActions)
+                                    )
+                                |> ConcurrentTask.onError
+                                    (\_ ->
+                                        ConcurrentTask.succeed <|
+                                            GotProposalGovActions (Err "Failed to fetch proposals transaction CBORs")
+                                    )
+
+                        govActionTasks =
+                            if List.isEmpty chainableProposals then
+                                []
+
+                            else
+                                [ fetchGovActionsTask ]
+
                         ( newPool, cmds ) =
                             ConcurrentTask.attemptEach { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete }
-                                (List.map completeReadProposalMetadataTask activeProposals)
+                                (List.map completeReadProposalMetadataTask activeProposals
+                                    ++ govActionTasks
+                                )
 
                         updatedModel =
                             { model
@@ -1682,6 +1731,23 @@ handleCompletedTask response model =
             else
                 ( updatedModel, Cmd.none )
 
+        ( ConcurrentTask.Success (GotProposalGovActions result), _ ) ->
+            case result of
+                Err _ ->
+                    ( model, Cmd.none )
+
+                Ok govActions ->
+                    let
+                        newRelationships =
+                            recomputeProposalRelationships model.proposals govActions
+                    in
+                    ( { model
+                        | proposalGovActions = govActions
+                        , proposalRelationships = newRelationships
+                      }
+                    , Cmd.none
+                    )
+
         ( ConcurrentTask.Success (GotCart cart), _ ) ->
             let
                 updatedModel =
@@ -1714,6 +1780,152 @@ handleCompletedTask response model =
 
         ( ConcurrentTask.Success (PreparationTaskCompleted _), _ ) ->
             ( model, Cmd.none )
+
+
+{-| Recompute proposal relationships from the current proposals and decoded gov actions.
+-}
+recomputeProposalRelationships : WebData (Dict String ActiveProposal) -> Dict String Gov.Action -> Dict String ProposalRelInfo
+recomputeProposalRelationships proposalsData govActions =
+    case proposalsData of
+        RemoteData.Success proposals ->
+            let
+                -- Build the list of chainable proposals with their decoded latestEnacted
+                chainableWithActions : List ( String, ActiveProposal, Maybe Gov.ActionId )
+                chainableWithActions =
+                    Dict.toList proposals
+                        |> List.filter (\( _, p ) -> isChainableAction p.actionType)
+                        |> List.filterMap
+                            (\( bech32Id, proposal ) ->
+                                case Dict.get bech32Id govActions of
+                                    Just action ->
+                                        Just ( bech32Id, proposal, ProposalRelationships.actionLatestEnacted action )
+
+                                    Nothing ->
+                                        -- Gov action not yet decoded, skip for now
+                                        Nothing
+                            )
+            in
+            ProposalRelationships.proposalRelationships chainableWithActions
+
+        _ ->
+            Dict.empty
+
+
+
+-- TODO: REMOVE - Mock data for testing proposal relationship badges
+-- Scenario:
+--   #1 ParameterChange (epoch 550) — competing with #2
+--   #2 ParameterChange (epoch 551) — competing with #1
+--   #3 ParameterChange (epoch 553) — follows #1
+--   #4 NoConfidence    (epoch 552) — delaying, competing with #5
+--   #5 UpdateCommittee (epoch 554) — delaying, competing with #4
+
+
+mockActionId : String -> Int -> Gov.ActionId
+mockActionId hexPair index =
+    -- hexPair is a 2-char hex like "aa", "bb", etc. Repeat to fill 64 hex chars (32 bytes).
+    { transactionId = Bytes.fromHexUnchecked (String.repeat 32 hexPair)
+    , govActionIndex = index
+    }
+
+
+mockProposal : String -> Int -> String -> Int -> Int -> ActiveProposal
+mockProposal hexSuffix index actionType startEpoch endEpoch =
+    { id = mockActionId hexSuffix index
+    , actionType = actionType
+    , metadataUrl = ""
+    , metadataHash = ""
+    , epoch_validity = { start = startEpoch, end = endEpoch }
+    , ratified = Nothing
+    , metadata = RemoteData.Success { raw = "", computedHash = "", body = { title = Just ("Mock " ++ actionType ++ " " ++ hexSuffix), abstract = Just "Mock proposal for testing relationship badges." }, authors = [] }
+    }
+
+
+mockProposals : Int -> List ( String, ActiveProposal )
+mockProposals currentEpoch =
+    let
+        p1 =
+            mockProposal "aa" 0 "ParameterChange" currentEpoch (currentEpoch + 6)
+
+        p2 =
+            mockProposal "bb" 0 "ParameterChange" currentEpoch (currentEpoch + 6)
+
+        p3 =
+            mockProposal "cc" 0 "ParameterChange" currentEpoch (currentEpoch + 6)
+
+        p4 =
+            mockProposal "dd" 0 "NoConfidence" currentEpoch (currentEpoch + 6)
+
+        p5 =
+            mockProposal "ee" 0 "NewCommittee" currentEpoch (currentEpoch + 6)
+    in
+    [ ( Helper.actionIdToBech32 p1.id, p1 )
+    , ( Helper.actionIdToBech32 p2.id, p2 )
+    , ( Helper.actionIdToBech32 p3.id, p3 )
+    , ( Helper.actionIdToBech32 p4.id, p4 )
+    , ( Helper.actionIdToBech32 p5.id, p5 )
+    ]
+
+
+{-| The "already enacted" action that #1 and #2 both reference (not an active proposal).
+-}
+mockEnactedActionId : Gov.ActionId
+mockEnactedActionId =
+    mockActionId "ff" 0
+
+
+{-| The "already enacted" committee action that #4 and #5 both reference.
+-}
+mockEnactedCommitteeActionId : Gov.ActionId
+mockEnactedCommitteeActionId =
+    mockActionId "ee" 1
+
+
+mockGovActions : Dict String Gov.Action
+mockGovActions =
+    let
+        bech32 hexSuffix =
+            Helper.actionIdToBech32 (mockActionId hexSuffix 0)
+    in
+    Dict.fromList
+        [ -- #1 and #2 both reference the same enacted action (competing)
+          ( bech32 "aa"
+          , Gov.ParameterChange
+                { latestEnacted = Just mockEnactedActionId
+                , protocolParamUpdate = Gov.noParamUpdate
+                , guardrailsPolicy = Nothing
+                }
+          )
+        , ( bech32 "bb"
+          , Gov.ParameterChange
+                { latestEnacted = Just mockEnactedActionId
+                , protocolParamUpdate = Gov.noParamUpdate
+                , guardrailsPolicy = Nothing
+                }
+          )
+
+        -- #3 follows #1 (its latestEnacted points to mock "aa")
+        , ( bech32 "cc"
+          , Gov.ParameterChange
+                { latestEnacted = Just (mockActionId "aa" 0)
+                , protocolParamUpdate = Gov.noParamUpdate
+                , guardrailsPolicy = Nothing
+                }
+          )
+
+        -- #4 and #5 share CommitteePurpose and same latestEnacted (competing + delaying)
+        , ( bech32 "dd"
+          , Gov.NoConfidence { latestEnacted = Just mockEnactedCommitteeActionId }
+          )
+        , ( bech32 "ee"
+          , Gov.UpdateCommittee
+                { latestEnacted = Just mockEnactedCommitteeActionId
+                , removedMembers = []
+                , addedMembers = []
+                , quorumThreshold = { numerator = 2, denominator = 3 }
+                }
+          )
+        ]
 
 
 
@@ -1864,6 +2076,19 @@ viewContent model =
 
                         _ ->
                             Nothing
+
+                -- TODO: REMOVE - Inject mock proposals and relationships at view time only
+                currentEpoch =
+                    RemoteData.withDefault 0 model.epoch
+
+                mockProps =
+                    mockProposals currentEpoch
+
+                proposalsWithMocks =
+                    RemoteData.map (\ps -> Dict.union ps (Dict.fromList mockProps)) model.proposals
+
+                mockRels =
+                    recomputeProposalRelationships proposalsWithMocks (Dict.union mockGovActions model.proposalGovActions)
             in
             Page.Preparation.view
                 { wrapMsg = PreparationPageMsg
@@ -1872,7 +2097,7 @@ viewContent model =
                 , drepId = model.walletDrepId
                 , epoch = RemoteData.toMaybe model.epoch
                 , cart = model.cart
-                , proposals = model.proposals
+                , proposals = proposalsWithMocks
                 , jsonLdContexts = model.jsonLdContexts
                 , costModels = Maybe.map .costModels model.protocolParams
                 , constitutionUri = model.constitutionUri
@@ -1885,6 +2110,7 @@ viewContent model =
                         link (RouteSigning { networkId = model.networkId, tx = Just tx, expectedSigners = expectedSigners }) []
                 , ipfsPreconfig = model.ipfsPreconfig
                 , voterPreconfig = model.voterPreconfig
+                , proposalRelationships = mockRels
                 }
                 prepModel
 

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -1812,122 +1812,6 @@ recomputeProposalRelationships proposalsData govActions =
 
 
 
--- TODO: REMOVE - Mock data for testing proposal relationship badges
--- Scenario:
---   #1 ParameterChange (epoch 550) — competing with #2
---   #2 ParameterChange (epoch 551) — competing with #1
---   #3 ParameterChange (epoch 553) — follows #1
---   #4 NoConfidence    (epoch 552) — delaying, competing with #5
---   #5 UpdateCommittee (epoch 554) — delaying, competing with #4
-
-
-mockActionId : String -> Int -> Gov.ActionId
-mockActionId hexPair index =
-    -- hexPair is a 2-char hex like "aa", "bb", etc. Repeat to fill 64 hex chars (32 bytes).
-    { transactionId = Bytes.fromHexUnchecked (String.repeat 32 hexPair)
-    , govActionIndex = index
-    }
-
-
-mockProposal : String -> Int -> String -> Int -> Int -> ActiveProposal
-mockProposal hexSuffix index actionType startEpoch endEpoch =
-    { id = mockActionId hexSuffix index
-    , actionType = actionType
-    , metadataUrl = ""
-    , metadataHash = ""
-    , epoch_validity = { start = startEpoch, end = endEpoch }
-    , ratified = Nothing
-    , metadata = RemoteData.Success { raw = "", computedHash = "", body = { title = Just ("Mock " ++ actionType ++ " " ++ hexSuffix), abstract = Just "Mock proposal for testing relationship badges." }, authors = [] }
-    }
-
-
-mockProposals : Int -> List ( String, ActiveProposal )
-mockProposals currentEpoch =
-    let
-        p1 =
-            mockProposal "aa" 0 "ParameterChange" currentEpoch (currentEpoch + 6)
-
-        p2 =
-            mockProposal "bb" 0 "ParameterChange" currentEpoch (currentEpoch + 6)
-
-        p3 =
-            mockProposal "cc" 0 "ParameterChange" currentEpoch (currentEpoch + 6)
-
-        p4 =
-            mockProposal "dd" 0 "NoConfidence" currentEpoch (currentEpoch + 6)
-
-        p5 =
-            mockProposal "ee" 0 "NewCommittee" currentEpoch (currentEpoch + 6)
-    in
-    [ ( Helper.actionIdToBech32 p1.id, p1 )
-    , ( Helper.actionIdToBech32 p2.id, p2 )
-    , ( Helper.actionIdToBech32 p3.id, p3 )
-    , ( Helper.actionIdToBech32 p4.id, p4 )
-    , ( Helper.actionIdToBech32 p5.id, p5 )
-    ]
-
-
-{-| The "already enacted" action that #1 and #2 both reference (not an active proposal).
--}
-mockEnactedActionId : Gov.ActionId
-mockEnactedActionId =
-    mockActionId "ff" 0
-
-
-{-| The "already enacted" committee action that #4 and #5 both reference.
--}
-mockEnactedCommitteeActionId : Gov.ActionId
-mockEnactedCommitteeActionId =
-    mockActionId "ee" 1
-
-
-mockGovActions : Dict String Gov.Action
-mockGovActions =
-    let
-        bech32 hexSuffix =
-            Helper.actionIdToBech32 (mockActionId hexSuffix 0)
-    in
-    Dict.fromList
-        [ -- #1 and #2 both reference the same enacted action (competing)
-          ( bech32 "aa"
-          , Gov.ParameterChange
-                { latestEnacted = Just mockEnactedActionId
-                , protocolParamUpdate = Gov.noParamUpdate
-                , guardrailsPolicy = Nothing
-                }
-          )
-        , ( bech32 "bb"
-          , Gov.ParameterChange
-                { latestEnacted = Just mockEnactedActionId
-                , protocolParamUpdate = Gov.noParamUpdate
-                , guardrailsPolicy = Nothing
-                }
-          )
-
-        -- #3 follows #1 (its latestEnacted points to mock "aa")
-        , ( bech32 "cc"
-          , Gov.ParameterChange
-                { latestEnacted = Just (mockActionId "aa" 0)
-                , protocolParamUpdate = Gov.noParamUpdate
-                , guardrailsPolicy = Nothing
-                }
-          )
-
-        -- #4 and #5 share CommitteePurpose and same latestEnacted (competing + delaying)
-        , ( bech32 "dd"
-          , Gov.NoConfidence { latestEnacted = Just mockEnactedCommitteeActionId }
-          )
-        , ( bech32 "ee"
-          , Gov.UpdateCommittee
-                { latestEnacted = Just mockEnactedCommitteeActionId
-                , removedMembers = []
-                , addedMembers = []
-                , quorumThreshold = { numerator = 2, denominator = 3 }
-                }
-          )
-        ]
-
-
 
 -- #########################################################
 -- VIEW
@@ -2077,18 +1961,6 @@ viewContent model =
                         _ ->
                             Nothing
 
-                -- TODO: REMOVE - Inject mock proposals and relationships at view time only
-                currentEpoch =
-                    RemoteData.withDefault 0 model.epoch
-
-                mockProps =
-                    mockProposals currentEpoch
-
-                proposalsWithMocks =
-                    RemoteData.map (\ps -> Dict.union ps (Dict.fromList mockProps)) model.proposals
-
-                mockRels =
-                    recomputeProposalRelationships proposalsWithMocks (Dict.union mockGovActions model.proposalGovActions)
             in
             Page.Preparation.view
                 { wrapMsg = PreparationPageMsg
@@ -2097,7 +1969,7 @@ viewContent model =
                 , drepId = model.walletDrepId
                 , epoch = RemoteData.toMaybe model.epoch
                 , cart = model.cart
-                , proposals = proposalsWithMocks
+                , proposals = model.proposals
                 , jsonLdContexts = model.jsonLdContexts
                 , costModels = Maybe.map .costModels model.protocolParams
                 , constitutionUri = model.constitutionUri
@@ -2110,7 +1982,7 @@ viewContent model =
                         link (RouteSigning { networkId = model.networkId, tx = Just tx, expectedSigners = expectedSigners }) []
                 , ipfsPreconfig = model.ipfsPreconfig
                 , voterPreconfig = model.voterPreconfig
-                , proposalRelationships = mockRels
+                , proposalRelationships = model.proposalRelationships
                 }
                 prepModel
 

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -36,7 +36,6 @@ import Cardano.Gov as Gov exposing (ActionId, Anchor, CostModels, Id(..), Vote)
 import Cardano.Pool as Pool
 import Cardano.Script as Script
 import Cardano.Transaction as Transaction exposing (Transaction)
-import Cardano.TxIntent exposing (VoteIntent)
 import Cardano.Utxo as Utxo exposing (Output, OutputReference)
 import Cardano.Witness as Witness
 import Cbor.Encode
@@ -65,6 +64,7 @@ import Page.Cart as Cart
 import Platform.Cmd as Cmd
 import Process
 import ProposalMetadata exposing (AuthorWitness, ProposalMetadata)
+import ProposalRelationships exposing (ProposalRelInfo)
 import RemoteData exposing (RemoteData, WebData)
 import ScriptInfo exposing (ScriptInfo)
 import Set exposing (Set)
@@ -3252,6 +3252,7 @@ type alias ViewContext msg =
     , signingLink : Transaction -> List { keyName : String, keyHash : Bytes CredentialHash } -> List (Html msg) -> Html msg
     , ipfsPreconfig : { label : String, description : String }
     , voterPreconfig : List PreconfVoter
+    , proposalRelationships : Dict String ProposalRelInfo
     }
 
 
@@ -3792,13 +3793,23 @@ viewProposalList ctx form maybeVoter proposalsDict visibleCount =
                 proposalsInValidEpoch
                     |> List.filter (\p -> roleCanVoteOn p.actionType)
 
+            -- TODO: REMOVE - Mock bech32 IDs to exclude from proposal list
+            mockInCartIds =
+                Set.fromList
+                    [ Helper.actionIdToBech32 { transactionId = Bytes.fromHexUnchecked (String.repeat 32 "ee"), govActionIndex = 0 }
+                    , Helper.actionIdToBech32 { transactionId = Bytes.fromHexUnchecked (String.repeat 32 "cc"), govActionIndex = 0 }
+                    ]
+
             proposalsNotInCart =
-                case maybeVoterId of
+                (case maybeVoterId of
                     Just voterId ->
                         List.filter (\p -> not <| Cart.contains voterId p.id ctx.cart) proposalsForVoter
 
                     Nothing ->
                         proposalsForVoter
+                )
+                    -- TODO: REMOVE - Also filter out mock cart entries
+                    |> List.filter (\p -> not <| Set.member (Helper.actionIdToBech32 p.id) mockInCartIds)
 
             totalProposalCount =
                 List.length proposalsNotInCart
@@ -3825,14 +3836,13 @@ viewProposalList ctx form maybeVoter proposalsDict visibleCount =
                     1
 
             visibleProposals =
-                List.sortBy (\proposal -> ( hasPastVote proposal.id, proposal.epoch_validity.end )) proposalsNotInCart
+                List.sortBy (\proposal -> ( hasPastVote proposal.id, proposal.epoch_validity.end, ( proposal.actionType, Helper.actionIdToBech32 proposal.id ) )) proposalsNotInCart
                     |> List.take visibleCount
 
             hasMore =
                 totalProposalCount > visibleCount
 
             -- Proposals already in the cart for the selected voter.
-            votesInCart : List { proposalTitle : String, voteIntent : VoteIntent }
             votesInCart =
                 case maybeVoterId of
                     Nothing ->
@@ -3840,24 +3850,60 @@ viewProposalList ctx form maybeVoter proposalsDict visibleCount =
 
                     Just voterIdStr ->
                         Cart.getVoter voterIdStr ctx.cart
-                            |> Dict.values
+                            |> Dict.toList
+                            |> List.map
+                                (\( actionIdStr, { proposalTitle, voteIntent } ) ->
+                                    { proposalTitle = proposalTitle
+                                    , voteIntent = voteIntent
+                                    , relInfo =
+                                        Dict.get actionIdStr ctx.proposalRelationships
+                                            |> Maybe.map (\info -> { number = info.number, follows = info.follows, competingWith = info.competingWith, isDelaying = info.isDelaying })
+                                    }
+                                )
+
+            -- TODO: REMOVE - Mock cart entries for testing relationship badges
+            mockVoteIntent actionId =
+                { vote = Gov.VoteAbstain
+                , actionId = actionId
+                , rationale = Nothing
+                }
+
+            mockCartEntries =
+                let
+                    eeId =
+                        { transactionId = Bytes.fromHexUnchecked (String.repeat 32 "ee"), govActionIndex = 0 }
+
+                    ccId =
+                        { transactionId = Bytes.fromHexUnchecked (String.repeat 32 "cc"), govActionIndex = 0 }
+
+                    eeRel =
+                        Dict.get (Helper.actionIdToBech32 eeId) ctx.proposalRelationships
+                            |> Maybe.map (\info -> { number = info.number, follows = info.follows, competingWith = info.competingWith, isDelaying = info.isDelaying })
+
+                    ccRel =
+                        Dict.get (Helper.actionIdToBech32 ccId) ctx.proposalRelationships
+                            |> Maybe.map (\info -> { number = info.number, follows = info.follows, competingWith = info.competingWith, isDelaying = info.isDelaying })
+                in
+                [ { proposalTitle = "Mock NewCommittee ee", voteIntent = mockVoteIntent eeId, relInfo = eeRel }
+                , { proposalTitle = "Mock ParameterChange cc", voteIntent = mockVoteIntent ccId, relInfo = ccRel }
+                ]
         in
         div []
             [ Helper.proposalListContainer
                 "Select a proposal to vote on"
                 totalProposalCount
-                (List.map (viewProposalCardHelper ctx.wrapMsg ctx.networkId ctx.epoch getPastVote) visibleProposals)
+                (List.map (viewProposalCardHelper ctx.wrapMsg ctx.networkId ctx.epoch getPastVote ctx.proposalRelationships) visibleProposals)
             , Helper.showMoreButton
                 hasMore
                 visibleCount
                 totalProposalCount
                 (ctx.wrapMsg (ShowMoreProposals visibleCount))
-            , Helper.viewProposalsListInCart votesInCart
+            , Helper.viewProposalsListInCart (votesInCart ++ mockCartEntries)
             ]
 
 
-viewProposalCardHelper : (Msg -> msg) -> NetworkId -> Maybe Int -> (ActionId -> Maybe OnchainVote) -> ActiveProposal -> Html msg
-viewProposalCardHelper wrapMsg networkId currentEpoch getPastVote proposal =
+viewProposalCardHelper : (Msg -> msg) -> NetworkId -> Maybe Int -> (ActionId -> Maybe OnchainVote) -> Dict String ProposalRelInfo -> ActiveProposal -> Html msg
+viewProposalCardHelper wrapMsg networkId currentEpoch getPastVote relationships proposal =
     let
         idString =
             Helper.actionIdToBech32 proposal.id
@@ -3901,6 +3947,10 @@ viewProposalCardHelper wrapMsg networkId currentEpoch getPastVote proposal =
 
         linkHex =
             Helper.shortenedHex 5 (Bytes.toHex proposal.id.transactionId)
+
+        relInfo =
+            Dict.get idString relationships
+                |> Maybe.map (\info -> { number = info.number, follows = info.follows, competingWith = info.competingWith, isDelaying = info.isDelaying })
     in
     Helper.proposalCard
         { hashIsValid = hashIsValid
@@ -3914,6 +3964,7 @@ viewProposalCardHelper wrapMsg networkId currentEpoch getPastVote proposal =
         , linkUrl = linkUrl
         , linkHex = linkHex
         , index = proposal.id.govActionIndex
+        , relInfo = relInfo
         }
         (wrapMsg (PickProposalButtonClicked idString))
         (Helper.viewActionTypeIcon proposal.actionType)

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -3793,23 +3793,13 @@ viewProposalList ctx form maybeVoter proposalsDict visibleCount =
                 proposalsInValidEpoch
                     |> List.filter (\p -> roleCanVoteOn p.actionType)
 
-            -- TODO: REMOVE - Mock bech32 IDs to exclude from proposal list
-            mockInCartIds =
-                Set.fromList
-                    [ Helper.actionIdToBech32 { transactionId = Bytes.fromHexUnchecked (String.repeat 32 "ee"), govActionIndex = 0 }
-                    , Helper.actionIdToBech32 { transactionId = Bytes.fromHexUnchecked (String.repeat 32 "cc"), govActionIndex = 0 }
-                    ]
-
             proposalsNotInCart =
-                (case maybeVoterId of
+                case maybeVoterId of
                     Just voterId ->
                         List.filter (\p -> not <| Cart.contains voterId p.id ctx.cart) proposalsForVoter
 
                     Nothing ->
                         proposalsForVoter
-                )
-                    -- TODO: REMOVE - Also filter out mock cart entries
-                    |> List.filter (\p -> not <| Set.member (Helper.actionIdToBech32 p.id) mockInCartIds)
 
             totalProposalCount =
                 List.length proposalsNotInCart
@@ -3861,32 +3851,6 @@ viewProposalList ctx form maybeVoter proposalsDict visibleCount =
                                     }
                                 )
 
-            -- TODO: REMOVE - Mock cart entries for testing relationship badges
-            mockVoteIntent actionId =
-                { vote = Gov.VoteAbstain
-                , actionId = actionId
-                , rationale = Nothing
-                }
-
-            mockCartEntries =
-                let
-                    eeId =
-                        { transactionId = Bytes.fromHexUnchecked (String.repeat 32 "ee"), govActionIndex = 0 }
-
-                    ccId =
-                        { transactionId = Bytes.fromHexUnchecked (String.repeat 32 "cc"), govActionIndex = 0 }
-
-                    eeRel =
-                        Dict.get (Helper.actionIdToBech32 eeId) ctx.proposalRelationships
-                            |> Maybe.map (\info -> { number = info.number, follows = info.follows, competingWith = info.competingWith, isDelaying = info.isDelaying })
-
-                    ccRel =
-                        Dict.get (Helper.actionIdToBech32 ccId) ctx.proposalRelationships
-                            |> Maybe.map (\info -> { number = info.number, follows = info.follows, competingWith = info.competingWith, isDelaying = info.isDelaying })
-                in
-                [ { proposalTitle = "Mock NewCommittee ee", voteIntent = mockVoteIntent eeId, relInfo = eeRel }
-                , { proposalTitle = "Mock ParameterChange cc", voteIntent = mockVoteIntent ccId, relInfo = ccRel }
-                ]
         in
         div []
             [ Helper.proposalListContainer
@@ -3898,7 +3862,7 @@ viewProposalList ctx form maybeVoter proposalsDict visibleCount =
                 visibleCount
                 totalProposalCount
                 (ctx.wrapMsg (ShowMoreProposals visibleCount))
-            , Helper.viewProposalsListInCart (votesInCart ++ mockCartEntries)
+            , Helper.viewProposalsListInCart votesInCart
             ]
 
 

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -3850,7 +3850,6 @@ viewProposalList ctx form maybeVoter proposalsDict visibleCount =
                                             |> Maybe.map (\info -> { number = info.number, follows = info.follows, competingWith = info.competingWith, isDelaying = info.isDelaying })
                                     }
                                 )
-
         in
         div []
             [ Helper.proposalListContainer

--- a/frontend/src/ProposalRelationships.elm
+++ b/frontend/src/ProposalRelationships.elm
@@ -1,0 +1,307 @@
+module ProposalRelationships exposing
+    ( GovernancePurpose(..), ProposalRelInfo
+    , actionLatestEnacted, isChainableAction, proposalRelationships
+    )
+
+{-| Module for computing governance proposal relationships.
+
+Cardano Conway-era governance proposals that share the same "purpose" and
+reference the same `latestEnacted` action are competing: only one can be
+enacted, the rest expire. This module provides the types and logic to
+detect and represent these relationships.
+
+@docs GovernancePurpose, ProposalRelInfo
+@docs actionLatestEnacted, isChainableAction, proposalRelationships
+
+-}
+
+import Api exposing (ActiveProposal)
+import Cardano.Gov as Gov exposing (ActionId)
+import Dict exposing (Dict)
+import Set exposing (Set)
+
+
+{-| The governance purpose of a chainable proposal.
+Proposals sharing the same purpose and latestEnacted reference are competing.
+-}
+type GovernancePurpose
+    = CommitteePurpose
+    | ConstitutionPurpose
+    | HardForkPurpose
+    | PParamUpdatePurpose
+
+
+{-| Relationship info for a single proposal, used to display
+dependency and competition tags on proposal cards.
+-}
+type alias ProposalRelInfo =
+    { number : Int
+    , purpose : GovernancePurpose
+    , latestEnacted : Maybe ActionId
+    , follows : Maybe Int
+    , competingWith : List Int
+    , isDelaying : Bool
+    }
+
+
+{-| Check if an action type string corresponds to a chainable action
+(one that participates in purpose chains and can conflict).
+-}
+isChainableAction : String -> Bool
+isChainableAction actionType =
+    case actionType of
+        "ParameterChange" ->
+            True
+
+        "HardForkInitiation" ->
+            True
+
+        "NoConfidence" ->
+            True
+
+        "NewCommittee" ->
+            True
+
+        "NewConstitution" ->
+            True
+
+        _ ->
+            False
+
+
+{-| Extract the latestEnacted field from a Gov.Action, if applicable.
+-}
+actionLatestEnacted : Gov.Action -> Maybe ActionId
+actionLatestEnacted action =
+    case action of
+        Gov.ParameterChange { latestEnacted } ->
+            latestEnacted
+
+        Gov.HardForkInitiation { latestEnacted } ->
+            latestEnacted
+
+        Gov.NoConfidence { latestEnacted } ->
+            latestEnacted
+
+        Gov.UpdateCommittee { latestEnacted } ->
+            latestEnacted
+
+        Gov.NewConstitution { latestEnacted } ->
+            latestEnacted
+
+        Gov.TreasuryWithdrawals _ ->
+            Nothing
+
+        Gov.Info ->
+            Nothing
+
+
+{-| Determine the governance purpose from an action type string.
+-}
+actionPurpose : String -> Maybe GovernancePurpose
+actionPurpose actionType =
+    case actionType of
+        "ParameterChange" ->
+            Just PParamUpdatePurpose
+
+        "HardForkInitiation" ->
+            Just HardForkPurpose
+
+        "NoConfidence" ->
+            Just CommitteePurpose
+
+        "NewCommittee" ->
+            Just CommitteePurpose
+
+        "NewConstitution" ->
+            Just ConstitutionPurpose
+
+        _ ->
+            Nothing
+
+
+{-| Given a list of (bech32Id, ActiveProposal, Maybe ActionId) triples
+for chainable proposals, compute the ProposalRelInfo for each.
+
+Only proposals that are in a relationship (follows another, is followed by
+another, or competes with another) get an entry. Numbering is time-based:
+older proposals (by proposed epoch) get lower numbers.
+
+-}
+proposalRelationships :
+    List ( String, ActiveProposal, Maybe ActionId )
+    -> Dict String ProposalRelInfo
+proposalRelationships chainableProposals =
+    let
+        -- Sort to match the display order in the view: expiry, then type, then id
+        sorted =
+            List.sortBy (\( bech32Id, p, _ ) -> ( p.epoch_validity.end, p.actionType, bech32Id )) chainableProposals
+
+        -- Set of active proposal ActionId strings, for detecting "follows"
+        activeActionIds : Set String
+        activeActionIds =
+            sorted
+                |> List.map (\( _, p, _ ) -> Gov.actionIdToString p.id)
+                |> Set.fromList
+
+        -- For each proposal, compute whether it follows an active proposal
+        followsLookup : Dict String String
+        followsLookup =
+            sorted
+                |> List.filterMap
+                    (\( bech32Id, _, latestEnacted ) ->
+                        latestEnacted
+                            |> Maybe.map Gov.actionIdToString
+                            |> Maybe.andThen
+                                (\aidStr ->
+                                    if Set.member aidStr activeActionIds then
+                                        Just ( bech32Id, aidStr )
+
+                                    else
+                                        Nothing
+                                )
+                    )
+                |> Dict.fromList
+
+        -- Set of ActionId strings that are followed by at least one proposal
+        followedActionIds : Set String
+        followedActionIds =
+            Dict.values followsLookup |> Set.fromList
+
+        -- Group proposals by (purpose, latestEnacted) to detect competing siblings.
+        -- A group with >1 member means those proposals are competing.
+        competingGroups : List (List String)
+        competingGroups =
+            sorted
+                |> List.filterMap
+                    (\( bech32Id, proposal, latestEnacted ) ->
+                        actionPurpose proposal.actionType
+                            |> Maybe.map
+                                (\purpose ->
+                                    ( ( purposeToString purpose
+                                      , Maybe.map Gov.actionIdToString latestEnacted |> Maybe.withDefault "genesis"
+                                      )
+                                    , bech32Id
+                                    )
+                                )
+                    )
+                |> groupByFirst
+                |> List.filter (\group -> List.length group > 1)
+
+        -- Map each bech32Id to its competing siblings (excluding itself)
+        competingLookup : Dict String (List String)
+        competingLookup =
+            competingGroups
+                |> List.concatMap
+                    (\group ->
+                        List.map (\bech32Id -> ( bech32Id, List.filter (\other -> other /= bech32Id) group )) group
+                    )
+                |> Dict.fromList
+
+        competingBech32Ids : Set String
+        competingBech32Ids =
+            Dict.keys competingLookup |> Set.fromList
+
+        -- A proposal is "in a relationship" if it follows, is followed, or competes
+        hasRelationship ( bech32Id, proposal, _ ) =
+            Dict.member bech32Id followsLookup
+                || Set.member (Gov.actionIdToString proposal.id) followedActionIds
+                || Set.member bech32Id competingBech32Ids
+
+        -- Filter to only proposals with relationships, preserving sorted order
+        relatedProposals =
+            List.filter hasRelationship sorted
+
+        -- Assign numbers only to related proposals
+        actionIdToNumber : Dict String Int
+        actionIdToNumber =
+            relatedProposals
+                |> List.indexedMap
+                    (\i ( _, proposal, _ ) ->
+                        ( Gov.actionIdToString proposal.id, i + 1 )
+                    )
+                |> Dict.fromList
+
+        bech32ToNumber : Dict String Int
+        bech32ToNumber =
+            relatedProposals
+                |> List.indexedMap (\i ( bech32Id, _, _ ) -> ( bech32Id, i + 1 ))
+                |> Dict.fromList
+
+        toRelInfo : Int -> ( String, ActiveProposal, Maybe ActionId ) -> ( String, ProposalRelInfo )
+        toRelInfo index ( bech32Id, proposal, latestEnacted ) =
+            let
+                purpose =
+                    actionPurpose proposal.actionType
+                        |> Maybe.withDefault PParamUpdatePurpose
+
+                follows =
+                    latestEnacted
+                        |> Maybe.andThen (\aid -> Dict.get (Gov.actionIdToString aid) actionIdToNumber)
+
+                competingWith =
+                    Dict.get bech32Id competingLookup
+                        |> Maybe.withDefault []
+                        |> List.filterMap (\siblingId -> Dict.get siblingId bech32ToNumber)
+                        |> List.sort
+
+                isDelaying =
+                    case proposal.actionType of
+                        "ParameterChange" ->
+                            False
+
+                        _ ->
+                            -- All other chainable types are delaying
+                            True
+            in
+            ( bech32Id
+            , { number = index + 1
+              , purpose = purpose
+              , latestEnacted = latestEnacted
+              , follows = follows
+              , competingWith = competingWith
+              , isDelaying = isDelaying
+              }
+            )
+    in
+    relatedProposals
+        |> List.indexedMap toRelInfo
+        |> Dict.fromList
+
+
+{-| Group a list of (key, value) pairs by key, returning list of value groups.
+-}
+groupByFirst : List ( comparable, a ) -> List (List a)
+groupByFirst pairs =
+    List.foldl
+        (\( key, value ) acc ->
+            Dict.update key
+                (\existing ->
+                    case existing of
+                        Nothing ->
+                            Just [ value ]
+
+                        Just values ->
+                            Just (value :: values)
+                )
+                acc
+        )
+        Dict.empty
+        pairs
+        |> Dict.values
+
+
+purposeToString : GovernancePurpose -> String
+purposeToString purpose =
+    case purpose of
+        CommitteePurpose ->
+            "committee"
+
+        ConstitutionPurpose ->
+            "constitution"
+
+        HardForkPurpose ->
+            "hardfork"
+
+        PParamUpdatePurpose ->
+            "pparam"


### PR DESCRIPTION
Solves #149 

Competing and dependent governance proposal relationships on the preparation page.

In Cardano Conway-era governance, chainable proposals (ParameterChange, HardForkInitiation, NoConfidence, UpdateCommittee, NewConstitution) reference a `latestEnacted` action. Proposals sharing the same purpose and `latestEnacted` reference are **competing**: only one can be enacted, the rest expire. A proposal can also **follow** another active proposal, creating a dependency chain. This information was previously invisible to voters.

## What's new

### Data pipeline

- **Batch tx CBOR fetching** (`Api.elm`): after proposals load, a single batch request fetches the CBOR of all transactions containing chainable proposals. The decoded transactions are used to extract the `latestEnacted` field from each governance action.
- **`ProposalRelationships` module** (new): dedicated module that computes proposal relationships from the decoded governance actions. It detects:
  - **Follows**: proposal A references active proposal B as its `latestEnacted` (A depends on B being enacted first)
  - **Competing**: proposals sharing the same purpose and `latestEnacted` reference (only one can be enacted)
  - **Delaying**: actions (all chainable types except ParameterChange) that, if ratified, block all other ratifications for the rest of the epoch
- **Numbering**: only proposals that are actually in a relationship (follows, is followed, or competes) are assigned sequential numbers (1, 2, ...) based on display order (expiry epoch, action type, proposal id).

### UI badges

Four color-coded badges are displayed on proposal cards and in the "Votes already in cart" section of the preparation page:

| Badge | Color | Meaning |
|-------|-------|---------|
| **#N** | Grey | Proposal number for cross-referencing |
| **Follows #M** | Amber | This proposal depends on #M being enacted first |
| **Competing #N, #M** | Red | These proposals share the same purpose and parent action; only one can be enacted |
| **Delaying** | Purple | If ratified, delays all other ratifications for the epoch |

Each badge has a tooltip explaining its meaning on hover.

<img width="1036" height="399" alt="image" src="https://github.com/user-attachments/assets/4c5158e8-f180-411c-93c3-52aca027c250" />

<img width="795" height="227" alt="image" src="https://github.com/user-attachments/assets/07fc2521-3c74-45e8-ac98-a1a20aeb1e4b" />


### Mock data (temporary)

Mock proposals and cart entries are injected at view time only (not in the model) to visualize the badges during development. All mock code is marked with `TODO: REMOVE` comments for easy cleanup.

## Files changed

| File | Changes |
|------|---------|
| `src/ProposalRelationships.elm` | New module: types (`GovernancePurpose`, `ProposalRelInfo`) and relationship computation logic |
| `src/Api.elm` | Added `taskRetrieveTxBatch` for batch CBOR fetching |
| `src/Main.elm` | Model extensions, CBOR fetch trigger, relationship computation, mock data injection at view time |
| `src/Page/Preparation.elm` | Pass relationship info to proposal cards and cart section |
| `src/Helper.elm` | `viewRelBadges` function rendering the four badge types with tooltips |
