### PR TITLE
Fix detection of spent sponsored utxos

### DIFF
--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -1151,8 +1151,8 @@ taskGetUtxoInfo networkId txHash outputIndex =
                     "https://api.koios.rest/api/v1"
 
         decoder =
-            JD.list JD.value
-                |> JD.map (\items -> not (List.isEmpty items))
+            JD.list (JD.field "is_spent" JD.bool)
+                |> JD.map (\items -> items == [ False ])
     in
     ConcurrentTask.Http.post
         { url = "/proxy/json"


### PR DESCRIPTION
Now correctly detects already spent utxos for HLabs sponsing.

<img width="358" height="191" alt="image" src="https://github.com/user-attachments/assets/2a173d90-6505-4455-972e-5cd27bb43617" />
