### PR TITLE
Faster proposals page loading

### DIFF
--- a/frontend/elm.json
+++ b/frontend/elm.json
@@ -7,7 +7,6 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "MartinSStewart/elm-uint64": "2.0.0",
             "andrewMacmurray/elm-concurrent-task": "2.0.0",
             "dillonkearns/elm-markdown": "7.0.1",
             "dwayne/elm-integer": "1.0.0",
@@ -23,9 +22,10 @@
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm-cardano/bech32": "1.0.0",
+            "elm-cardano/blake2b": "2.0.0",
+            "elm-cardano/x-bytes": "1.1.0",
             "elm-toulouse/cbor": "4.0.1",
             "elmcraft/core-extra": "2.2.0",
-            "jxxcarlson/hex": "4.0.1",
             "krisajenkins/remotedata": "6.1.0",
             "lydell/elm-app-url": "1.0.4",
             "myrho/numeral-elm": "1.0.1",
@@ -37,6 +37,7 @@
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
             "elm/virtual-dom": "1.0.4",
+            "elm-cardano/base64": "1.0.1",
             "elm-toulouse/float16": "1.0.1",
             "myrho/elm-round": "1.0.5",
             "rtfeldman/elm-hex": "1.0.0"

--- a/frontend/src/Page/Cart.elm
+++ b/frontend/src/Page/Cart.elm
@@ -130,11 +130,18 @@ type alias Resources =
 
 {-| Check if a given proposal is present in the cart.
 -}
-contains : String -> ActionId -> Model -> Bool
-contains voterId actionId model =
-    get voterId actionId model
-        |> Maybe.map (\_ -> True)
-        |> Maybe.withDefault False
+contains : { voterId : String, actionId : String } -> Model -> Bool
+contains { voterId, actionId } model =
+    case model of
+        Preparing { votersIntents } ->
+            Dict.get voterId votersIntents
+                |> Maybe.map (\{ voteRecords } -> Dict.member actionId voteRecords)
+                |> Maybe.withDefault False
+
+        Ready { votersIntents } ->
+            Dict.get voterId votersIntents
+                |> Maybe.map (\{ voteRecords } -> Dict.member actionId voteRecords)
+                |> Maybe.withDefault False
 
 
 {-| Try to retrieve a vote from the cart.

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -3778,8 +3778,10 @@ viewProposalList ctx form maybeVoter proposalsDict visibleCount =
             currentEpoch =
                 Maybe.withDefault 0 ctx.epoch
 
-            proposalsDictValues =
-                Dict.values proposalsDict
+            -- proposalsDict is already keyed by bech32 id, so we keep the (idStr, proposal)
+            -- pairs all the way through the pipeline to avoid re-encoding bech32.
+            proposalsDictPairs =
+                Dict.toList proposalsDict
 
             maybeVoterId =
                 Maybe.map (Witness.toVoter >> Gov.voterToId >> Gov.idToBech32) maybeVoter
@@ -3817,17 +3819,17 @@ viewProposalList ctx form maybeVoter proposalsDict visibleCount =
 
             -- Remove proposals already in the cart from that list for this voter
             proposalsInValidEpoch =
-                proposalsDictValues
-                    |> List.filter (\p -> p.epoch_validity.end > currentEpoch)
+                proposalsDictPairs
+                    |> List.filter (\( _, p ) -> p.epoch_validity.end > currentEpoch)
 
             proposalsForVoter =
                 proposalsInValidEpoch
-                    |> List.filter (\p -> roleCanVoteOn p.actionType)
+                    |> List.filter (\( _, p ) -> roleCanVoteOn p.actionType)
 
             proposalsNotInCart =
                 case maybeVoterId of
                     Just voterId ->
-                        List.filter (\p -> not <| Cart.contains voterId p.id ctx.cart) proposalsForVoter
+                        List.filter (\( idStr, _ ) -> not <| Cart.contains { voterId = voterId, actionId = idStr } ctx.cart) proposalsForVoter
 
                     Nothing ->
                         proposalsForVoter
@@ -3849,16 +3851,26 @@ viewProposalList ctx form maybeVoter proposalsDict visibleCount =
             getPastVote actionId =
                 Dict.get (Gov.idToBech32 <| GovActionId actionId) pastVotes
 
-            hasPastVote actionId =
-                if getPastVote actionId == Nothing then
-                    0
-
-                else
+            hasPastVoteByStr idStr =
+                if Dict.member idStr pastVotes then
                     1
 
+                else
+                    0
+
+            -- Decorate-sort-undecorate: compute the sort key once per proposal
+            -- instead of re-evaluating it during every comparison.
             visibleProposals =
-                List.sortBy (\proposal -> ( hasPastVote proposal.id, proposal.epoch_validity.end, ( proposal.actionType, Helper.actionIdToBech32 proposal.id ) )) proposalsNotInCart
+                proposalsNotInCart
+                    |> List.map
+                        (\( idStr, p ) ->
+                            ( ( hasPastVoteByStr idStr, p.epoch_validity.end, ( p.actionType, idStr ) )
+                            , p
+                            )
+                        )
+                    |> List.sortBy Tuple.first
                     |> List.take visibleCount
+                    |> List.map Tuple.second
 
             hasMore =
                 totalProposalCount > visibleCount

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -26,7 +26,7 @@ The steps are sequential but allow going back to modify previous steps.
 -}
 
 import Api exposing (ActiveProposal, AuthorVerification, CcInfo, DrepInfo, IpfsAnswer(..), OnchainVote, PoolInfo)
-import Blake2b exposing (blake2b256)
+import Blake2b256
 import Browser.Dom as Dom
 import Bytes as ElmBytes
 import Bytes.Comparable as Bytes exposing (Bytes)
@@ -1735,10 +1735,9 @@ handleTaskCompleted task (Model model) =
                                 , identifier = uploadedIdentifierFromUri form.publishedRationaleUri
                                 , raw = rawJson
                                 , dataHash =
-                                    Bytes.fromText rawJson
-                                        |> Bytes.toU8
-                                        |> blake2b256 Nothing
-                                        |> Bytes.fromU8
+                                    Blake2b256.fromString rawJson
+                                        |> Blake2b256.toHex
+                                        |> Bytes.fromHexUnchecked
                                 }
                         in
                         ( Model { model | permanentStorageStep = Done { form | error = Nothing } { jsonFile = uploadedFile } }
@@ -3164,10 +3163,9 @@ handleRationaleIpfsAnswer model form ipfsAnswer =
                     , identifier = IpfsIdentifier file.cid
                     , raw = rawJson
                     , dataHash =
-                        Bytes.fromText rawJson
-                            |> Bytes.toU8
-                            |> blake2b256 Nothing
-                            |> Bytes.fromU8
+                        Blake2b256.fromString rawJson
+                            |> Blake2b256.toHex
+                            |> Bytes.fromHexUnchecked
                     }
 
                 downloadCmd =
@@ -3237,10 +3235,9 @@ allPrepSteps m =
                             Just
                                 { url = uploadedIdentifierToUri s.jsonFile.identifier
                                 , dataHash =
-                                    Bytes.fromText s.jsonFile.raw
-                                        |> Bytes.toU8
-                                        |> blake2b256 Nothing
-                                        |> Bytes.fromU8
+                                    Blake2b256.fromString s.jsonFile.raw
+                                        |> Blake2b256.toHex
+                                        |> Bytes.fromHexUnchecked
                                 }
                         }
 

--- a/frontend/src/ProposalMetadata.elm
+++ b/frontend/src/ProposalMetadata.elm
@@ -3,7 +3,7 @@ module ProposalMetadata exposing (AuthorWitness, Body, ProposalMetadata, authorW
 {-| Helper module to handle proposals metadata following [CIP-108](https://cips.cardano.org/cip/CIP-0108).
 -}
 
-import Bytes.Comparable as Bytes
+import Blake2b256
 import Json.Decode as JD exposing (Decoder, Value)
 import Json.Encode as JE
 
@@ -75,9 +75,8 @@ fromRaw : String -> ProposalMetadata
 fromRaw raw =
     let
         computedHash =
-            Bytes.fromText raw
-                |> Bytes.blake2b256
-                |> Bytes.toHex
+            Blake2b256.fromString raw
+                |> Blake2b256.toHex
 
         authorsDecoder =
             JD.field "authors" (JD.list authorWitnessDecoder)


### PR DESCRIPTION
As reported and confirmed in #165, the page load time would increase a lot when many big proposals were loading.

The main culprit was our old blake2b implementation, dating from the early days of elm-cardano, verifying the proposal hash to check that the proposal was not changed. It could take a couple second per proposal, so with dozens of proposals, it’s a long time with the app being non-interactive / janky.

Here is a screenshot of the flame graph with the blake2b culprit.

<img width="1435" height="978" alt="Image" src="https://github.com/user-attachments/assets/7861a37e-1737-411f-80e8-49514110e308" />

Now this PR fixes the blake2b implementation. Now uses a new implementation, that was recently rewritten to improve the elm-cardano framework, yielding over 100x faster implementation than previously.

This PR also introduces a small optimization in the `viewProposalList` function to avoid repetitive bech32 conversion computations.

Thanks to both these changes, the loading that previously took ~20s, now takes ~200ms.

<img width="1131" height="616" alt="image" src="https://github.com/user-attachments/assets/a8cf822f-4ea6-4293-a296-f1191cb461b9" />
