### PR TITLE
Enable multi-ipfs storage config

### DIFF
--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -1823,7 +1823,7 @@ storageConfigItem label content =
 
 
 {-| Title + description header used at the top of a provider config block.
-Matches the inline h4 + p block that's repeated across `viewPublishProviderInfo`
+Matches the inline h4 + p block that's repeated across `viewIpfsProviderInfo`
 branches in `Page/Preparation.elm`.
 -}
 storageProviderHeader : String -> String -> Html msg

--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -2,7 +2,7 @@ module Helper exposing
     ( actionIdToBech32, actionIdFromBech32
     , ipfsToHttpsUrl, ipfsToGatewaySelectorUrl, shortenedHex, prettyAdaLovelace
     , textFieldInline, textInputField
-    , formContainer, boxContainer, viewGrid, cardContainer, cardHeader, cardContent, nestedSurface
+    , formContainer, boxContainer, viewGrid, cardContainer, cardHeader, cardContent, nestedCard
     , viewButton, viewWalletButton, externalLink, externalLinkButton, trashButton
     , applyDropdownContainerStyle, applyDropdownItemStyle, applyMobileDropdownContainerStyle, applyWalletIconContainerStyle, applyWalletIconStyle
     , viewActionTypeIcon
@@ -44,7 +44,7 @@ and are potentially useful in multiple places.
 
 # Containers
 
-@docs formContainer, boxContainer, viewGrid, cardContainer, cardHeader, cardContent, nestedSurface
+@docs formContainer, boxContainer, viewGrid, cardContainer, cardHeader, cardContent, nestedCard
 
 
 # Buttons
@@ -616,12 +616,11 @@ cardContent attributes content =
         content
 
 
-{-| Inset surface for grouping a sub-step inside an existing card.
-Renders with the project's secondary surface tokens (#F7FAFC / #EDF2F7).
+{-| Inset card for grouping a sub-step inside an existing card.
 The `sub` line is rendered only when non-empty.
 -}
-nestedSurface : { heading : String, sub : String } -> List (Html msg) -> Html msg
-nestedSurface { heading, sub } children =
+nestedCard : { heading : String, sub : String } -> List (Html msg) -> Html msg
+nestedCard { heading, sub } children =
     div
         [ HA.style "background-color" "#F7FAFC"
         , HA.style "border" "1px solid #EDF2F7"

--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -15,7 +15,7 @@ module Helper exposing
     , storageConfigCard, storageMethodOption, storageProviderForm, storageProviderCard, storageConfigItem, addHeaderButton
     , storageHeaderForm, storageInfoGrid, storageNotAvailableCard, storageUploadCard, uploadingSpinner, storageSuccessCard, fileInfoItem, externalLinkDisplay
     , rationaleCard, checkbox, rationaleMarkdownInput, rationaleTextArea, pdfAutogenCheckbox, voteNumberInput, referenceCard, referenceForm
-    , rationaleCompletedCard, optionalSection, formattedInternalVote, formattedReferences
+    , rationaleCompletedCard, viewPartialFailuresWithIntro, optionalSection, formattedInternalVote, formattedReferences
     , stepNotAvailableCard, downloadJSONButton, authorsCard, addAuthorButton, codeSnippetBox, noAuthorsPlaceholder
     , signerCard, authorForm, labeledField, readOnlyField, formButtonsRow, secondaryButton, primaryButton, importSignedRationaleButton
     , stepCard, missingStepsList, missingStepItem, loadingSpinner
@@ -97,7 +97,7 @@ and are potentially useful in multiple places.
 # Rationale Components
 
 @docs rationaleCard, checkbox, rationaleMarkdownInput, rationaleTextArea, pdfAutogenCheckbox, voteNumberInput, referenceCard, referenceForm
-@docs rationaleCompletedCard, optionalSection, formattedInternalVote, formattedReferences
+@docs rationaleCompletedCard, viewPartialFailuresWithIntro, optionalSection, formattedInternalVote, formattedReferences
 
 
 # Document Creation Components
@@ -2258,29 +2258,64 @@ referenceForm index typeName label uri deleteMsg typeChangeMsg labelChangeMsg ur
 
 {-| Card for completed rationale
 -}
-rationaleCompletedCard : String -> List (Html msg) -> msg -> Html msg
-rationaleCompletedCard summary content editMsg =
+rationaleCompletedCard : String -> List (Html msg) -> List (Html msg) -> msg -> Html msg
+rationaleCompletedCard summary content belowCard editMsg =
     div []
-        [ sectionTitle "Vote Rationale"
-        , cardContainer []
-            [ cardHeader [] "Rationale Summary" "" []
-            , cardContent []
-                [ div [ HA.style "display" "grid", HA.style "gap" "1.5rem" ]
-                    (div []
-                        [ Html.p
-                            [ HA.style "font-size" "0.9375rem"
-                            , HA.style "line-height" "1.6"
-                            , HA.style "color" "#4A5568"
+        (sectionTitle "Vote Rationale"
+            :: cardContainer []
+                [ cardHeader [] "Rationale Summary" "" []
+                , cardContent []
+                    [ div [ HA.style "display" "grid", HA.style "gap" "1.5rem" ]
+                        (div []
+                            [ Html.p
+                                [ HA.style "font-size" "0.9375rem"
+                                , HA.style "line-height" "1.6"
+                                , HA.style "color" "#4A5568"
+                                ]
+                                [ text summary ]
                             ]
-                            [ text summary ]
-                        ]
-                        :: content
-                    )
+                            :: content
+                        )
+                    ]
                 ]
+            :: belowCard
+            ++ [ Html.p [ HA.style "margin-top" "1rem" ]
+                    [ viewButton "Edit rationale" editMsg ]
+               ]
+        )
+
+
+{-| Amber callout listing labeled failures under an intro line. Renders nothing
+when the list is empty.
+-}
+viewPartialFailuresWithIntro : String -> List ( String, String ) -> Html msg
+viewPartialFailuresWithIntro intro failures =
+    if List.isEmpty failures then
+        text ""
+
+    else
+        div
+            [ HA.style "margin" "1rem 0"
+            , HA.style "padding" "0.75rem 1rem"
+            , HA.style "border" "1px solid #FCD34D"
+            , HA.style "border-radius" "0.5rem"
+            , HA.style "background-color" "#FFFBEB"
+            , HA.style "color" "#92400E"
+            , HA.style "font-size" "0.875rem"
             ]
-        , Html.p [ HA.style "margin-top" "1rem" ]
-            [ viewButton "Edit rationale" editMsg ]
-        ]
+            [ Html.p [ HA.style "font-weight" "600", HA.style "margin-bottom" "0.5rem" ]
+                [ text intro ]
+            , Html.ul [ HA.style "padding-left" "1.25rem", HA.style "margin" "0" ]
+                (List.map
+                    (\( label, err ) ->
+                        Html.li [ HA.style "margin-bottom" "0.25rem" ]
+                            [ Html.strong [] [ text (label ++ ": ") ]
+                            , text err
+                            ]
+                    )
+                    failures
+                )
+            ]
 
 
 {-| Display optional section if content exists

--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -2,7 +2,7 @@ module Helper exposing
     ( actionIdToBech32, actionIdFromBech32
     , ipfsToHttpsUrl, ipfsToGatewaySelectorUrl, shortenedHex, prettyAdaLovelace
     , textFieldInline, textInputField
-    , formContainer, boxContainer, viewGrid, cardContainer, cardHeader, cardContent
+    , formContainer, boxContainer, viewGrid, cardContainer, cardHeader, cardContent, nestedSurface
     , viewButton, viewWalletButton, externalLink, externalLinkButton, trashButton
     , applyDropdownContainerStyle, applyDropdownItemStyle, applyMobileDropdownContainerStyle, applyWalletIconContainerStyle, applyWalletIconStyle
     , viewActionTypeIcon
@@ -12,7 +12,7 @@ module Helper exposing
     , PreconfAuthor, PreconfVoter, viewVoterGrid, viewVoterCard, voterCustomCard, votingPowerDisplay, scriptInfoContainer, viewVoterCredDetails, viewVoterDetailsItem, viewCredInfo
     , viewUtxoRefForm, scriptSignerSection, scriptSignerCheckbox, viewIdentifiedVoterCard, viewVoterInfoItem
     , proposalListContainer, showMoreButton, proposalCard, selectedProposalCard, proposalDetailsItem, viewProposalsListInCart
-    , storageConfigCard, storageMethodOption, storageProviderForm, storageProviderCard, storageConfigItem, addHeaderButton
+    , storageConfigCard, storageMethodOption, storageMethodCheckbox, storageProviderForm, storageProviderCard, storageConfigItem, storageProviderHeader, addHeaderButton
     , storageHeaderForm, storageInfoGrid, storageNotAvailableCard, storageUploadCard, uploadingSpinner, storageSuccessCard, fileInfoItem, externalLinkDisplay
     , rationaleCard, checkbox, rationaleMarkdownInput, rationaleTextArea, pdfAutogenCheckbox, voteNumberInput, referenceCard, referenceForm
     , rationaleCompletedCard, viewPartialFailuresWithIntro, optionalSection, formattedInternalVote, formattedReferences
@@ -44,7 +44,7 @@ and are potentially useful in multiple places.
 
 # Containers
 
-@docs formContainer, boxContainer, viewGrid, cardContainer, cardHeader, cardContent
+@docs formContainer, boxContainer, viewGrid, cardContainer, cardHeader, cardContent, nestedSurface
 
 
 # Buttons
@@ -90,7 +90,7 @@ and are potentially useful in multiple places.
 
 # Storage Configuration Components
 
-@docs storageConfigCard, storageMethodOption, storageProviderForm, storageProviderCard, storageConfigItem, addHeaderButton
+@docs storageConfigCard, storageMethodOption, storageMethodCheckbox, storageProviderForm, storageProviderCard, storageConfigItem, storageProviderHeader, addHeaderButton
 @docs storageHeaderForm, storageInfoGrid, storageNotAvailableCard, storageUploadCard, uploadingSpinner, storageSuccessCard, fileInfoItem, externalLinkDisplay
 
 
@@ -614,6 +614,41 @@ cardContent attributes content =
     div
         (HA.style "padding" "1.25rem" :: attributes)
         content
+
+
+{-| Inset surface for grouping a sub-step inside an existing card.
+Renders with the project's secondary surface tokens (#F7FAFC / #EDF2F7).
+The `sub` line is rendered only when non-empty.
+-}
+nestedSurface : { heading : String, sub : String } -> List (Html msg) -> Html msg
+nestedSurface { heading, sub } children =
+    div
+        [ HA.style "background-color" "#F7FAFC"
+        , HA.style "border" "1px solid #EDF2F7"
+        , HA.style "border-radius" "0.5rem"
+        , HA.style "padding" "0.85rem"
+        , HA.style "margin-top" "0.75rem"
+        ]
+        (Html.div
+            [ HA.style "font-weight" "600"
+            , HA.style "font-size" "0.9rem"
+            , HA.style "color" "#1A202C"
+            , HA.style "margin-bottom" "0.3rem"
+            ]
+            [ text heading ]
+            :: (if sub == "" then
+                    children
+
+                else
+                    Html.div
+                        [ HA.style "font-size" "0.78rem"
+                        , HA.style "color" "#4A5568"
+                        , HA.style "margin-bottom" "0.65rem"
+                        ]
+                        [ text sub ]
+                        :: children
+               )
+        )
 
 
 
@@ -1788,6 +1823,26 @@ storageConfigItem label content =
         ]
 
 
+{-| Title + description header used at the top of a provider config block.
+Matches the inline h4 + p block that's repeated across `viewPublishProviderInfo`
+branches in `Page/Preparation.elm`.
+-}
+storageProviderHeader : String -> String -> Html msg
+storageProviderHeader title description =
+    div []
+        [ Html.h4
+            [ HA.style "font-weight" "600"
+            , HA.style "margin-bottom" "0.5rem"
+            ]
+            [ text title ]
+        , Html.p
+            [ HA.style "color" "#4A5568"
+            , HA.style "font-size" "0.875rem"
+            ]
+            [ text description ]
+        ]
+
+
 {-| Helper button to add an HTTP header in custom IPFS configs.
 -}
 addHeaderButton : msg -> Html msg
@@ -1957,6 +2012,60 @@ storageMethodOption label isSelected selectMsg =
                 , HA.style "width" "1rem"
                 , HA.style "height" "1rem"
                 , HA.style "border-radius" "9999px"
+                , HA.style "background-color" "#272727"
+                , HA.style "color" "white"
+                , HA.style "display" "flex"
+                , HA.style "align-items" "center"
+                , HA.style "justify-content" "center"
+                , HA.style "font-size" "0.75rem"
+                ]
+                [ text "✓" ]
+
+          else
+            text ""
+        ]
+
+
+{-| Twin of `storageMethodOption` for multi-select groups: identical
+tile shape, but the selected-state chip in the top-right corner is a
+square checkbox glyph instead of a round radio chip.
+-}
+storageMethodCheckbox : String -> Bool -> msg -> Html msg
+storageMethodCheckbox label isSelected selectMsg =
+    div
+        [ HA.style "border"
+            (if isSelected then
+                "2px solid #272727"
+
+             else
+                "1px solid #E2E8F0"
+            )
+        , HA.style "border-radius" "0.5rem"
+        , HA.style "padding" "0.75rem"
+        , HA.style "cursor" "pointer"
+        , HA.style "background-color"
+            (if isSelected then
+                "#F1F5F9"
+
+             else
+                "#FFFFFF"
+            )
+        , HA.style "position" "relative"
+        , onClick selectMsg
+        ]
+        [ div
+            [ HA.style "font-weight" "500"
+            , HA.style "font-size" "0.9375rem"
+            ]
+            [ text label ]
+        , if isSelected then
+            div
+                [ HA.style "position" "absolute"
+                , HA.style "top" "0.5rem"
+                , HA.style "right" "0.5rem"
+                , HA.style "width" "1rem"
+                , HA.style "height" "1rem"
+                , HA.style "border-radius" "0.2rem"
                 , HA.style "background-color" "#272727"
                 , HA.style "color" "white"
                 , HA.style "display" "flex"
@@ -2258,35 +2367,34 @@ referenceForm index typeName label uri deleteMsg typeChangeMsg labelChangeMsg ur
 
 {-| Card for completed rationale
 -}
-rationaleCompletedCard : String -> List (Html msg) -> List (Html msg) -> msg -> Html msg
-rationaleCompletedCard summary content belowCard editMsg =
+rationaleCompletedCard : String -> List (Html msg) -> msg -> Html msg
+rationaleCompletedCard summary content editMsg =
     div []
-        (sectionTitle "Vote Rationale"
-            :: cardContainer []
-                [ cardHeader [] "Rationale Summary" "" []
-                , cardContent []
-                    [ div [ HA.style "display" "grid", HA.style "gap" "1.5rem" ]
-                        (div []
-                            [ Html.p
-                                [ HA.style "font-size" "0.9375rem"
-                                , HA.style "line-height" "1.6"
-                                , HA.style "color" "#4A5568"
-                                ]
-                                [ text summary ]
+        [ sectionTitle "Vote Rationale"
+        , cardContainer []
+            [ cardHeader [] "Rationale Summary" "" []
+            , cardContent []
+                [ div [ HA.style "display" "grid", HA.style "gap" "1.5rem" ]
+                    (div []
+                        [ Html.p
+                            [ HA.style "font-size" "0.9375rem"
+                            , HA.style "line-height" "1.6"
+                            , HA.style "color" "#4A5568"
                             ]
-                            :: content
-                        )
-                    ]
+                            [ text summary ]
+                        ]
+                        :: content
+                    )
                 ]
-            :: belowCard
-            ++ [ Html.p [ HA.style "margin-top" "1rem" ]
-                    [ viewButton "Edit rationale" editMsg ]
-               ]
-        )
+            ]
+        , Html.p [ HA.style "margin-top" "1rem" ]
+            [ viewButton "Edit rationale" editMsg ]
+        ]
 
 
-{-| Amber callout listing labeled failures under an intro line. Renders nothing
-when the list is empty.
+{-| Red callout listing labeled failures under an intro line. Renders nothing
+when the list is empty. Uses the same alert tokens as `viewError` so partial
+failures and full errors share one visual language.
 -}
 viewPartialFailuresWithIntro : String -> List ( String, String ) -> Html msg
 viewPartialFailuresWithIntro intro failures =
@@ -2295,17 +2403,37 @@ viewPartialFailuresWithIntro intro failures =
 
     else
         div
-            [ HA.style "margin" "1rem 0"
-            , HA.style "padding" "0.75rem 1rem"
-            , HA.style "border" "1px solid #FCD34D"
+            [ HA.style "background-color" "#FEF2F2"
+            , HA.style "border" "1px solid #FEE2E2"
             , HA.style "border-radius" "0.5rem"
-            , HA.style "background-color" "#FFFBEB"
-            , HA.style "color" "#92400E"
-            , HA.style "font-size" "0.875rem"
+            , HA.style "padding" "1rem"
+            , HA.style "margin-top" "1rem"
             ]
-            [ Html.p [ HA.style "font-weight" "600", HA.style "margin-bottom" "0.5rem" ]
-                [ text intro ]
-            , Html.ul [ HA.style "padding-left" "1.25rem", HA.style "margin" "0" ]
+            [ Html.div
+                [ HA.style "display" "flex"
+                , HA.style "align-items" "center"
+                , HA.style "margin-bottom" "0.5rem"
+                ]
+                [ Html.span
+                    [ HA.style "color" "#DC2626"
+                    , HA.style "font-weight" "bold"
+                    , HA.style "margin-right" "0.5rem"
+                    , HA.style "font-size" "1.25rem"
+                    ]
+                    [ text "!" ]
+                , Html.p
+                    [ HA.style "color" "#DC2626"
+                    , HA.style "font-weight" "600"
+                    , HA.style "margin" "0"
+                    ]
+                    [ text intro ]
+                ]
+            , Html.ul
+                [ HA.style "padding-left" "1.25rem"
+                , HA.style "margin" "0"
+                , HA.style "color" "#991B1B"
+                , HA.style "font-size" "0.875rem"
+                ]
                 (List.map
                     (\( label, err ) ->
                         Html.li [ HA.style "margin-bottom" "0.25rem" ]

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -1027,7 +1027,7 @@ handleUrlChange route model =
                 newModel =
                     { model
                         | errors = []
-                        , page = PreparationPage <| Page.Preparation.init model.ipfsPreconfig
+                        , page = PreparationPage Page.Preparation.init
                         , appUrl = appUrl
                         , pendingProposalId = proposalId
                     }
@@ -1043,7 +1043,7 @@ handleUrlChange route model =
                 reloadLatestStorageConfigTask : ConcurrentTask String StorageConfig
                 reloadLatestStorageConfigTask =
                     Storage.read { db = model.db, storeName = "app" } Page.Preparation.storageConfigDecoder { key = "lastStorageConfig" }
-                        |> ConcurrentTask.onError (\_ -> ConcurrentTask.succeed <| Page.Preparation.initStorageConfig model.ipfsPreconfig)
+                        |> ConcurrentTask.onError (\_ -> ConcurrentTask.succeed Page.Preparation.initStorageConfig)
 
                 ( newTaskPool, taskCmds ) =
                     ConcurrentTask.attemptEach { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete }

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -674,6 +674,7 @@ update msg model =
                             , constitutionUri = model.constitutionUri
                             , networkId = model.networkId
                             , authorPreconfig = model.authorPreconfig
+                            , ipfsPreconfig = model.ipfsPreconfig
                             }
 
                         ( newPageModel, cmds, msgToParent ) =

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -4860,7 +4860,6 @@ viewPublishProviderInfo ipfsPreconfig provider =
 
 
 
-
 --
 -- Rationale Step
 --

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -608,16 +608,6 @@ type StorageConfig
     | StorageNoRationale
 
 
-storedProviders : StorageConfig -> List IpfsProvider
-storedProviders config =
-    case config of
-        StorageIpfs providers ->
-            providers
-
-        _ ->
-            []
-
-
 {-| Initialize the default storage config.
 -}
 initStorageConfig : StorageConfig
@@ -691,7 +681,14 @@ storageConfigDecoder =
                 case kind of
                     "StorageIpfs" ->
                         JD.field "providers" (JD.list ipfsProviderDecoder)
-                            |> JD.map StorageIpfs
+                            |> JD.andThen
+                                (\providers ->
+                                    if List.isEmpty providers then
+                                        JD.fail "StorageIpfs requires at least one provider"
+
+                                    else
+                                        JD.succeed (StorageIpfs providers)
+                                )
 
                     "StorageCustomHosting" ->
                         JD.succeed StorageCustomHosting
@@ -2775,31 +2772,15 @@ pinPdfFile fileAsValue (Model model) =
             , Cmd.none
             )
 
-        ( Ok file, Done _ storageConfig, Validating form validating ) ->
-            let
-                providers =
-                    storedProviders storageConfig
-
-                kinds =
-                    List.map providerKind providers
-            in
-            if List.isEmpty providers then
-                ( Model
-                    { model
-                        | rationaleCreationStep =
-                            Preparing { form | error = Just "No IPFS provider selected to upload the PDF to." }
-                    }
-                , Cmd.none
-                )
-
-            else
-                ( Model
-                    { model
-                        | rationaleCreationStep =
-                            Validating form { validating | uploads = initUploadProgress kinds }
-                    }
-                , Cmd.batch (List.map (uploadFileCmd file) providers)
-                )
+        ( Ok file, Done _ (StorageIpfs providers), Validating form validating ) ->
+            ( Model
+                { model
+                    | rationaleCreationStep =
+                        Validating form
+                            { validating | uploads = initUploadProgress (List.map providerKind providers) }
+                }
+            , Cmd.batch (List.map (uploadFileCmd file) providers)
+            )
 
         -- Ignore if we aren't validating the rationale storage step
         _ ->
@@ -3213,31 +3194,14 @@ pinRationaleFile fileAsValue (Model model) =
             , Cmd.none
             )
 
-        ( Ok file, Done _ storageConfig, Validating form _ ) ->
-            let
-                providers =
-                    storedProviders storageConfig
-
-                kinds =
-                    List.map providerKind providers
-            in
-            if List.isEmpty providers then
-                ( Model
-                    { model
-                        | permanentStorageStep =
-                            Preparing { form | error = Just "No IPFS provider selected to upload the rationale to." }
-                    }
-                , Cmd.none
-                )
-
-            else
-                ( Model
-                    { model
-                        | permanentStorageStep =
-                            Validating form (initUploadProgress kinds)
-                    }
-                , Cmd.batch (List.map (uploadFileCmd file) providers)
-                )
+        ( Ok file, Done _ (StorageIpfs providers), Validating form _ ) ->
+            ( Model
+                { model
+                    | permanentStorageStep =
+                        Validating form (initUploadProgress (List.map providerKind providers))
+                }
+            , Cmd.batch (List.map (uploadFileCmd file) providers)
+            )
 
         -- Ignore if we aren't validating the rationale storage step
         _ ->

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -94,7 +94,7 @@ type alias InnerModel =
     , storageConfigStep : Step StorageConfigForm {} StorageConfig
     , rationaleCreationStep : Step RationaleForm RationaleValidating Rationale
     , rationaleSignatureStep : Step RationaleSignatureForm {} RationaleSignature
-    , permanentStorageStep : Step StorageForm UploadProgress Storage
+    , permanentStorageStep : Step StorageForm IpfsUploadProgress Storage
     , buildTxStep : Step BuildTxPrep {} {}
     , visibleProposalCount : Int
     , showCartToast : Bool
@@ -256,24 +256,24 @@ type alias Rationale =
 
 {-| Tracks the progress of fan-out IPFS uploads across multiple publish providers.
 -}
-type alias UploadProgress =
+type alias IpfsUploadProgress =
     { remaining : List ProviderKind
     , succeeded : List ( ProviderKind, IpfsFile )
     , failed : List ( ProviderKind, String )
     }
 
 
-emptyUploadProgress : UploadProgress
+emptyUploadProgress : IpfsUploadProgress
 emptyUploadProgress =
     { remaining = [], succeeded = [], failed = [] }
 
 
-initUploadProgress : List ProviderKind -> UploadProgress
+initUploadProgress : List ProviderKind -> IpfsUploadProgress
 initUploadProgress kinds =
     { remaining = kinds, succeeded = [], failed = [] }
 
 
-recordUploadResult : ProviderKind -> Result String IpfsAnswer -> UploadProgress -> UploadProgress
+recordUploadResult : ProviderKind -> Result String IpfsAnswer -> IpfsUploadProgress -> IpfsUploadProgress
 recordUploadResult kind result progress =
     let
         -- Assumes a single entry per ProviderKind in `remaining`. The form
@@ -293,7 +293,7 @@ recordUploadResult kind result progress =
             { progress | remaining = remaining, failed = ( kind, transportErr ) :: progress.failed }
 
 
-uploadProgressIsDone : UploadProgress -> Bool
+uploadProgressIsDone : IpfsUploadProgress -> Bool
 uploadProgressIsDone progress =
     List.isEmpty progress.remaining
 
@@ -378,7 +378,7 @@ and the per-provider upload progress.
 -}
 type alias RationaleValidating =
     { rationale : Rationale
-    , uploads : UploadProgress
+    , uploads : IpfsUploadProgress
     }
 
 
@@ -3371,7 +3371,7 @@ handlePdfIpfsAnswer ctx model form validating kind result =
                 ( model, Cmd.none, Nothing )
 
 
-handleRationaleIpfsAnswer : IpfsPreconfig -> InnerModel -> StorageForm -> UploadProgress -> ProviderKind -> Result String IpfsAnswer -> ( InnerModel, Cmd msg, Maybe MsgToParent )
+handleRationaleIpfsAnswer : IpfsPreconfig -> InnerModel -> StorageForm -> IpfsUploadProgress -> ProviderKind -> Result String IpfsAnswer -> ( InnerModel, Cmd msg, Maybe MsgToParent )
 handleRationaleIpfsAnswer ipfsPreconfig model form progress kind result =
     let
         newProgress =
@@ -5372,7 +5372,7 @@ viewPermanentStorageStep :
     -> Step {} {} ActiveProposal
     -> Step RationaleSignatureForm {} RationaleSignature
     -> Step StorageConfigForm {} StorageConfig
-    -> Step StorageForm UploadProgress Storage
+    -> Step StorageForm IpfsUploadProgress Storage
     -> Html msg
 viewPermanentStorageStep ctx pickProposalStep rationaleSignatureStep storageConfigStep step =
     Html.map ctx.wrapMsg <|

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -135,7 +135,7 @@ init =
         , reloadedLastVoter = False
         , voterStep = Preparing initVoterForm
         , pickProposalStep = Preparing {}
-        , storageConfigStep = Done initStorageConfigForm (StoragePublish [ PreconfigIpfs ])
+        , storageConfigStep = Done initStorageConfigForm (StorageIpfs [ PreconfigIpfs ])
         , rationaleCreationStep = Preparing initRationaleForm
         , rationaleSignatureStep = Preparing initRationaleSignatureForm
         , permanentStorageStep = Preparing initStorageForm
@@ -326,12 +326,12 @@ providerKindDescription ipfsPreconfig kind =
 
 
 {-| User-facing label/description for the three non-publish storage modes.
-Returns `Nothing` for `StoragePublish`, whose info is derived per-provider.
+Returns `Nothing` for `StorageIpfs`, whose info is derived per-provider.
 -}
 storageConfigInfo : StorageConfig -> Maybe { label : String, description : String }
 storageConfigInfo config =
     case config of
-        StoragePublish _ ->
+        StorageIpfs _ ->
             Nothing
 
         StorageCustomHosting ->
@@ -471,7 +471,7 @@ the rationale is either published to IPFS, hosted manually by the user,
 already published, or absent.
 -}
 type StorageMode
-    = ModePublish
+    = ModeIpfs
     | ModeCustomHosting
     | ModePrepublished
     | ModeNoStorage
@@ -541,7 +541,7 @@ type alias StorageConfigForm =
 
 initStorageConfigForm : StorageConfigForm
 initStorageConfigForm =
-    { mode = ModePublish
+    { mode = ModeIpfs
     , publishSet = { emptyPublishSet | preconfig = True }
     , nmkrUserId = ""
     , nmkrApiToken = ""
@@ -555,9 +555,9 @@ initStorageConfigForm =
 formFromStorageConfig : StorageConfig -> StorageConfigForm
 formFromStorageConfig config =
     case config of
-        StoragePublish providers ->
+        StorageIpfs providers ->
             List.foldl applyProviderToForm
-                { initStorageConfigForm | mode = ModePublish, publishSet = emptyPublishSet }
+                { initStorageConfigForm | mode = ModeIpfs, publishSet = emptyPublishSet }
                 providers
 
         StorageCustomHosting ->
@@ -570,7 +570,7 @@ formFromStorageConfig config =
             { initStorageConfigForm | mode = ModeNoStorage, publishSet = emptyPublishSet }
 
 
-applyProviderToForm : PublishProvider -> StorageConfigForm -> StorageConfigForm
+applyProviderToForm : IpfsProvider -> StorageConfigForm -> StorageConfigForm
 applyProviderToForm provider form =
     case provider of
         PreconfigIpfs ->
@@ -602,14 +602,14 @@ The user-facing label and description for each variant are not stored
 on the variant itself; they are derived at view time from `ProviderKind`
 (and, for `PreconfigIpfs`, from the app-init `IpfsPreconfig`).
 -}
-type PublishProvider
+type IpfsProvider
     = PreconfigIpfs
     | BlockfrostIpfs { projectId : String }
     | NmkrIpfs { userId : String, apiToken : String }
     | CustomIpfsProvider { ipfsServer : String, headers : List ( String, String ) }
 
 
-providerKind : PublishProvider -> ProviderKind
+providerKind : IpfsProvider -> ProviderKind
 providerKind provider =
     case provider of
         PreconfigIpfs ->
@@ -626,16 +626,16 @@ providerKind provider =
 
 
 type StorageConfig
-    = StoragePublish (List PublishProvider)
+    = StorageIpfs (List IpfsProvider)
     | StorageCustomHosting
     | StoragePrepublished
     | StorageNoRationale
 
 
-storedProviders : StorageConfig -> List PublishProvider
+storedProviders : StorageConfig -> List IpfsProvider
 storedProviders config =
     case config of
-        StoragePublish providers ->
+        StorageIpfs providers ->
             providers
 
         _ ->
@@ -646,16 +646,16 @@ storedProviders config =
 -}
 initStorageConfig : StorageConfig
 initStorageConfig =
-    StoragePublish [ PreconfigIpfs ]
+    StorageIpfs [ PreconfigIpfs ]
 
 
 encodeStorageConfig : StorageConfig -> JE.Value
 encodeStorageConfig config =
     case config of
-        StoragePublish providers ->
+        StorageIpfs providers ->
             JE.object
-                [ ( "kind", JE.string "StoragePublish" )
-                , ( "providers", JE.list encodePublishProvider providers )
+                [ ( "kind", JE.string "StorageIpfs" )
+                , ( "providers", JE.list encodeIpfsProvider providers )
                 ]
 
         StorageCustomHosting ->
@@ -668,8 +668,8 @@ encodeStorageConfig config =
             JE.object [ ( "kind", JE.string "StorageNoRationale" ) ]
 
 
-encodePublishProvider : PublishProvider -> JE.Value
-encodePublishProvider provider =
+encodeIpfsProvider : IpfsProvider -> JE.Value
+encodeIpfsProvider provider =
     case provider of
         PreconfigIpfs ->
             JE.object [ ( "type", JE.string "PreconfigIpfs" ) ]
@@ -713,9 +713,9 @@ storageConfigDecoder =
         |> JD.andThen
             (\kind ->
                 case kind of
-                    "StoragePublish" ->
-                        JD.field "providers" (JD.list publishProviderDecoder)
-                            |> JD.map StoragePublish
+                    "StorageIpfs" ->
+                        JD.field "providers" (JD.list ipfsProviderDecoder)
+                            |> JD.map StorageIpfs
 
                     "StorageCustomHosting" ->
                         JD.succeed StorageCustomHosting
@@ -731,8 +731,8 @@ storageConfigDecoder =
             )
 
 
-publishProviderDecoder : JD.Decoder PublishProvider
-publishProviderDecoder =
+ipfsProviderDecoder : JD.Decoder IpfsProvider
+ipfsProviderDecoder =
     JD.field "type" JD.string
         |> JD.andThen
             (\providerType ->
@@ -898,7 +898,7 @@ type Msg
     | GotCip100Verification String (Result Http.Error Api.Cip100VerificationResponse)
       -- Storage Config Step
     | StorageModeSelected StorageMode
-    | PublishProviderToggled ProviderKind Bool
+    | IpfsProviderToggled ProviderKind Bool
     | BlockfrostProjectIdChange String
     | NmkrUserIdChange String
     | NmkrApiTokenChange String
@@ -1282,7 +1282,7 @@ innerUpdate ctx msg model =
             , Nothing
             )
 
-        PublishProviderToggled kind value ->
+        IpfsProviderToggled kind value ->
             ( updateStorageConfigForm
                 (\form -> { form | publishSet = publishSetSet kind value form.publishSet })
                 model
@@ -2497,17 +2497,17 @@ validateIpfsForm form =
         ModeNoStorage ->
             Ok StorageNoRationale
 
-        ModePublish ->
+        ModeIpfs ->
             if publishSetIsEmpty form.publishSet then
                 Err "Please select at least one IPFS provider, or pick another mode."
 
             else
-                buildPublishProviders form
-                    |> Result.map StoragePublish
+                buildIpfsProviders form
+                    |> Result.map StorageIpfs
 
 
-buildPublishProviders : StorageConfigForm -> Result String (List PublishProvider)
-buildPublishProviders form =
+buildIpfsProviders : StorageConfigForm -> Result String (List IpfsProvider)
+buildIpfsProviders form =
     let
         s =
             form.publishSet
@@ -2844,7 +2844,7 @@ pinPdfFile fileAsValue (Model model) =
             ( Model model, Cmd.none )
 
 
-uploadFileCmd : File -> PublishProvider -> Cmd Msg
+uploadFileCmd : File -> IpfsProvider -> Cmd Msg
 uploadFileCmd file provider =
     case provider of
         PreconfigIpfs ->
@@ -4606,13 +4606,13 @@ viewStorageConfigStep ctx step =
                         ]
                     , Helper.storageConfigCard "Storage Mode"
                         [ Helper.viewGrid 240
-                            [ Helper.storageMethodOption "Publish to IPFS" (form.mode == ModePublish) (StorageModeSelected ModePublish)
+                            [ Helper.storageMethodOption "Publish to IPFS" (form.mode == ModeIpfs) (StorageModeSelected ModeIpfs)
                             , Helper.storageMethodOption "No Rationale" (form.mode == ModeNoStorage) (StorageModeSelected ModeNoStorage)
                             , Helper.storageMethodOption "Custom Storage" (form.mode == ModeCustomHosting) (StorageModeSelected ModeCustomHosting)
                             , Helper.storageMethodOption "Custom Storage - Prepublished" (form.mode == ModePrepublished) (StorageModeSelected ModePrepublished)
                             ]
-                        , if form.mode == ModePublish then
-                            viewPublishProviderSelection ctx form
+                        , if form.mode == ModeIpfs then
+                            viewIpfsProviderSelection ctx form
 
                           else
                             text ""
@@ -4637,8 +4637,8 @@ viewStorageConfigStep ctx step =
                 ]
 
 
-viewPublishProviderSelection : ViewContext msg -> StorageConfigForm -> Html Msg
-viewPublishProviderSelection ctx form =
+viewIpfsProviderSelection : ViewContext msg -> StorageConfigForm -> Html Msg
+viewIpfsProviderSelection ctx form =
     let
         s =
             form.publishSet
@@ -4649,10 +4649,10 @@ viewPublishProviderSelection ctx form =
             , sub = "Pick one or more. We upload to each; the step passes if any succeed."
             }
             [ Helper.viewGrid 240
-                [ Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig PreconfigKind) s.preconfig (PublishProviderToggled PreconfigKind (not s.preconfig))
-                , Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig BlockfrostKind) s.blockfrost (PublishProviderToggled BlockfrostKind (not s.blockfrost))
-                , Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig NmkrKind) s.nmkr (PublishProviderToggled NmkrKind (not s.nmkr))
-                , Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig CustomIpfsKind) s.customIpfs (PublishProviderToggled CustomIpfsKind (not s.customIpfs))
+                [ Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig PreconfigKind) s.preconfig (IpfsProviderToggled PreconfigKind (not s.preconfig))
+                , Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig BlockfrostKind) s.blockfrost (IpfsProviderToggled BlockfrostKind (not s.blockfrost))
+                , Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig NmkrKind) s.nmkr (IpfsProviderToggled NmkrKind (not s.nmkr))
+                , Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig CustomIpfsKind) s.customIpfs (IpfsProviderToggled CustomIpfsKind (not s.customIpfs))
                 ]
             ]
         , if s.blockfrost then
@@ -4758,13 +4758,13 @@ viewCustomIpfsForm form =
 viewStorageConfigInfo : IpfsPreconfig -> StorageConfig -> Html msg
 viewStorageConfigInfo ipfsPreconfig config =
     case config of
-        StoragePublish providers ->
+        StorageIpfs providers ->
             div
                 [ HA.style "display" "flex"
                 , HA.style "flex-direction" "column"
                 , HA.style "gap" "1rem"
                 ]
-                (List.map (viewPublishProviderInfo ipfsPreconfig) providers)
+                (List.map (viewIpfsProviderInfo ipfsPreconfig) providers)
 
         _ ->
             case storageConfigInfo config of
@@ -4791,8 +4791,8 @@ defaultStorageConfigInfo label description =
         ]
 
 
-viewPublishProviderInfo : IpfsPreconfig -> PublishProvider -> Html msg
-viewPublishProviderInfo ipfsPreconfig provider =
+viewIpfsProviderInfo : IpfsPreconfig -> IpfsProvider -> Html msg
+viewIpfsProviderInfo ipfsPreconfig provider =
     let
         kind =
             providerKind provider
@@ -4918,7 +4918,7 @@ viewRationaleStep ctx pickProposalStep storageConfigStep step =
 isHostingAppControlled : StorageConfig -> Bool
 isHostingAppControlled storageConfig =
     case storageConfig of
-        StoragePublish _ ->
+        StorageIpfs _ ->
             True
 
         _ ->

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -273,100 +273,6 @@ initUploadProgress kinds =
     { remaining = kinds, succeeded = [], failed = [] }
 
 
-recordUploadResult : ProviderKind -> Result String IpfsAnswer -> IpfsUploadProgress -> IpfsUploadProgress
-recordUploadResult kind result progress =
-    let
-        -- Assumes a single entry per ProviderKind in `remaining`. The form
-        -- enforces this today (one toggle per kind); if that ever changes,
-        -- this filter would clear all duplicates at once.
-        remaining =
-            List.filter ((/=) kind) progress.remaining
-    in
-    case result of
-        Ok (IpfsAddSuccessful file) ->
-            { progress | remaining = remaining, succeeded = ( kind, file ) :: progress.succeeded }
-
-        Ok (IpfsError msg) ->
-            { progress | remaining = remaining, failed = ( kind, msg ) :: progress.failed }
-
-        Err transportErr ->
-            { progress | remaining = remaining, failed = ( kind, transportErr ) :: progress.failed }
-
-
-providerKindLabel : IpfsPreconfig -> ProviderKind -> String
-providerKindLabel ipfsPreconfig kind =
-    case kind of
-        PreconfigKind ->
-            ipfsPreconfig.label
-
-        BlockfrostKind ->
-            "Blockfrost"
-
-        NmkrKind ->
-            "NMKR"
-
-        CustomIpfsKind ->
-            "Custom IPFS"
-
-
-providerKindDescription : IpfsPreconfig -> ProviderKind -> String
-providerKindDescription ipfsPreconfig kind =
-    case kind of
-        PreconfigKind ->
-            ipfsPreconfig.description
-
-        BlockfrostKind ->
-            "Using Blockfrost IPFS server to store your files."
-
-        NmkrKind ->
-            "Using NMKR IPFS server to store your files. Remark that using NMKR own gateway will be faster to access pinned files: https://c-ipfs-gw.nmkr.io/ipfs/{file-hash-here}"
-
-        CustomIpfsKind ->
-            "Using a custom IPFS server configuration to store your files. The RPC should provide the /add?pin=true endpoint with answers equivalent to those described in the official kubo IPFS RPC docs: https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-add"
-
-
-{-| User-facing label/description for the three non-publish storage modes.
-Returns `Nothing` for `StorageIpfs`, whose info is derived per-provider.
--}
-storageConfigInfo : StorageConfig -> Maybe { label : String, description : String }
-storageConfigInfo config =
-    case config of
-        StorageIpfs _ ->
-            Nothing
-
-        StorageCustomHosting ->
-            Just
-                { label = "Custom Storage"
-                , description = "Prepare the rationale with this app, but store it on a custom solution (e.g. on GitHub via permanent links). It is your responsibility to make sure your storage solution is immutable and sustainable."
-                }
-
-        StoragePrepublished ->
-            Just
-                { label = "Custom Storage - Prepublished"
-                , description = "Your rationale is already published, we'll just link to it. It is your responsibility to ensure your storage solution is immutable and sustainable."
-                }
-
-        StorageNoRationale ->
-            Just
-                { label = "No Rationale"
-                , description = "Are you REALLY sure you don’t want to add a rationale? This is NOT RECOMMENDED because proposers, reviewers, and delegators cannot understand the reasoning behind your decision."
-                }
-
-
-storageConfigDescription : StorageConfig -> String
-storageConfigDescription config =
-    storageConfigInfo config
-        |> Maybe.map .description
-        |> Maybe.withDefault ""
-
-
-formatUploadFailures : IpfsPreconfig -> List ( ProviderKind, String ) -> String
-formatUploadFailures ipfsPreconfig failures =
-    failures
-        |> List.map (\( kind, err ) -> providerKindLabel ipfsPreconfig kind ++ ": " ++ err)
-        |> String.join "\n"
-
-
 {-| Validating state for the rationale creation step. While the PDF is being
 auto-generated and uploaded, we keep both the rationale being validated
 and the per-provider upload progress.
@@ -3359,6 +3265,33 @@ handleRationaleIpfsAnswer ipfsPreconfig model form progress kind result =
                 ( model, Cmd.none, Nothing )
 
 
+recordUploadResult : ProviderKind -> Result String IpfsAnswer -> IpfsUploadProgress -> IpfsUploadProgress
+recordUploadResult kind result progress =
+    let
+        -- Assumes a single entry per ProviderKind in `remaining`. The form
+        -- enforces this today (one toggle per kind); if that ever changes,
+        -- this filter would clear all duplicates at once.
+        remaining =
+            List.filter ((/=) kind) progress.remaining
+    in
+    case result of
+        Ok (IpfsAddSuccessful file) ->
+            { progress | remaining = remaining, succeeded = ( kind, file ) :: progress.succeeded }
+
+        Ok (IpfsError msg) ->
+            { progress | remaining = remaining, failed = ( kind, msg ) :: progress.failed }
+
+        Err transportErr ->
+            { progress | remaining = remaining, failed = ( kind, transportErr ) :: progress.failed }
+
+
+formatUploadFailures : IpfsPreconfig -> List ( ProviderKind, String ) -> String
+formatUploadFailures ipfsPreconfig failures =
+    failures
+        |> List.map (\( kind, err ) -> providerKindLabel ipfsPreconfig kind ++ ": " ++ err)
+        |> String.join "\n"
+
+
 
 -- Build Tx Step
 
@@ -4779,6 +4712,38 @@ viewIpfsProviderInfo ipfsPreconfig provider =
                 ]
 
 
+providerKindLabel : IpfsPreconfig -> ProviderKind -> String
+providerKindLabel ipfsPreconfig kind =
+    case kind of
+        PreconfigKind ->
+            ipfsPreconfig.label
+
+        BlockfrostKind ->
+            "Blockfrost"
+
+        NmkrKind ->
+            "NMKR"
+
+        CustomIpfsKind ->
+            "Custom IPFS"
+
+
+providerKindDescription : IpfsPreconfig -> ProviderKind -> String
+providerKindDescription ipfsPreconfig kind =
+    case kind of
+        PreconfigKind ->
+            ipfsPreconfig.description
+
+        BlockfrostKind ->
+            "Using Blockfrost IPFS server to store your files."
+
+        NmkrKind ->
+            "Using NMKR IPFS server to store your files. Remark that using NMKR own gateway will be faster to access pinned files: https://c-ipfs-gw.nmkr.io/ipfs/{file-hash-here}"
+
+        CustomIpfsKind ->
+            "Using a custom IPFS server configuration to store your files. The RPC should provide the /add?pin=true endpoint with answers equivalent to those described in the official kubo IPFS RPC docs: https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-add"
+
+
 
 --
 -- Rationale Step
@@ -4838,6 +4803,41 @@ viewRationaleStep ctx pickProposalStep storageConfigStep step =
                     [ Helper.sectionTitle "Vote Rationale"
                     , Helper.stepNotAvailableCard [ text "Please pick a proposal and validate the storage config step first." ]
                     ]
+
+
+storageConfigDescription : StorageConfig -> String
+storageConfigDescription config =
+    storageConfigInfo config
+        |> Maybe.map .description
+        |> Maybe.withDefault ""
+
+
+{-| User-facing label/description for the three non-publish storage modes.
+Returns `Nothing` for `StorageIpfs`, whose info is derived per-provider.
+-}
+storageConfigInfo : StorageConfig -> Maybe { label : String, description : String }
+storageConfigInfo config =
+    case config of
+        StorageIpfs _ ->
+            Nothing
+
+        StorageCustomHosting ->
+            Just
+                { label = "Custom Storage"
+                , description = "Prepare the rationale with this app, but store it on a custom solution (e.g. on GitHub via permanent links). It is your responsibility to make sure your storage solution is immutable and sustainable."
+                }
+
+        StoragePrepublished ->
+            Just
+                { label = "Custom Storage - Prepublished"
+                , description = "Your rationale is already published, we'll just link to it. It is your responsibility to ensure your storage solution is immutable and sustainable."
+                }
+
+        StorageNoRationale ->
+            Just
+                { label = "No Rationale"
+                , description = "Are you REALLY sure you don’t want to add a rationale? This is NOT RECOMMENDED because proposers, reviewers, and delegators cannot understand the reasoning behind your decision."
+                }
 
 
 isHostingAppControlled : StorageConfig -> Bool

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -1,4 +1,4 @@
-module Page.Preparation exposing (InternalVote, JsonLdContexts, LoadedWallet, Model, Msg, MsgToParent(..), Rationale, Reference, ReferenceType(..), StorageConfig, TaskCompleted, UpdateContext, ViewContext, encodeStorageConfig, handleTaskCompleted, init, initStorageConfig, noInternalVote, pickProposalMsg, pinPdfFile, pinRationaleFile, setLastStorageConfig, setLastVoter, storageConfigDecoder, update, view)
+module Page.Preparation exposing (InternalVote, IpfsPreconfig, JsonLdContexts, LoadedWallet, Model, Msg, MsgToParent(..), Rationale, Reference, ReferenceType(..), StorageConfig, TaskCompleted, UpdateContext, ViewContext, encodeStorageConfig, handleTaskCompleted, init, initStorageConfig, noInternalVote, pickProposalMsg, pinPdfFile, pinRationaleFile, setLastStorageConfig, setLastVoter, storageConfigDecoder, update, view)
 
 {-| This module handles the complete vote preparation workflow, from identifying
 the voter to signing the transaction, which is handled by another page.
@@ -295,26 +295,26 @@ uploadProgressIsDone progress =
     List.isEmpty progress.remaining
 
 
-providerKindLabel : ProviderKind -> String
-providerKindLabel kind =
+providerKindLabel : IpfsPreconfig -> ProviderKind -> String
+providerKindLabel ipfsPreconfig kind =
     case kind of
         PreconfigKind ->
-            "Preconfigured IPFS"
+            ipfsPreconfig.label
 
         BlockfrostKind ->
-            "Blockfrost IPFS"
+            "Blockfrost"
 
         NmkrKind ->
-            "NMKR IPFS"
+            "NMKR"
 
         CustomIpfsKind ->
             "Custom IPFS"
 
 
-formatUploadFailures : List ( ProviderKind, String ) -> String
-formatUploadFailures failures =
+formatUploadFailures : IpfsPreconfig -> List ( ProviderKind, String ) -> String
+formatUploadFailures ipfsPreconfig failures =
     failures
-        |> List.map (\( kind, err ) -> providerKindLabel kind ++ ": " ++ err)
+        |> List.map (\( kind, err ) -> providerKindLabel ipfsPreconfig kind ++ ": " ++ err)
         |> String.join "\n"
 
 
@@ -940,6 +940,10 @@ type Msg
     | EndFlyAnim
 
 
+type alias IpfsPreconfig =
+    { label : String, description : String }
+
+
 {-| Configuration required by the update function.
 Provides access to:
 
@@ -967,7 +971,7 @@ type alias UpdateContext msg =
     , constitutionUri : Maybe String
     , networkId : NetworkId
     , authorPreconfig : List PreconfAuthor
-    , ipfsPreconfig : { label : String, description : String }
+    , ipfsPreconfig : IpfsPreconfig
     }
 
 
@@ -1657,7 +1661,7 @@ innerUpdate ctx msg model =
                 -- Otherwise, if we are validating the permanent storage step, the IPFS answer
                 -- is for the signed JSON rationale upload.
                 ( _, Validating form progress ) ->
-                    handleRationaleIpfsAnswer model form progress kind result
+                    handleRationaleIpfsAnswer ctx.ipfsPreconfig model form progress kind result
 
                 _ ->
                     ( model, Cmd.none, Nothing )
@@ -2520,7 +2524,7 @@ buildPublishProviders ipfsPreconfig form =
                     projectId ->
                         Ok
                             (BlockfrostIpfs
-                                { label = "Own Blockfrost IPFS"
+                                { label = "Blockfrost"
                                 , description = "Using Blockfrost IPFS server to store your files."
                                 , projectId = projectId
                                 }
@@ -2539,7 +2543,7 @@ buildPublishProviders ipfsPreconfig form =
                     userId ->
                         Ok
                             (NmkrIpfs
-                                { label = "Own NMKR IPFS"
+                                { label = "NMKR"
                                 , description = "Using NMKR IPFS server to store your files. Remark that using NMKR own gateway will be faster to access pinned files: https://c-ipfs-gw.nmkr.io/ipfs/{file-hash-here}"
                                 , userId = userId
                                 , apiToken = form.nmkrApiToken
@@ -2573,7 +2577,7 @@ buildPublishProviders ipfsPreconfig form =
                     |> Result.map
                         (\_ ->
                             CustomIpfsProvider
-                                { label = "Custom IPFS Server"
+                                { label = "Custom IPFS"
                                 , description = "Using a custom IPFS server configuration to store your files. The RPC should provide the /add?pin=true endpoint with answers equivalent to those described in the official kubo IPFS RPC docs: https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-add"
                                 , ipfsServer = form.ipfsServer
                                 , headers = form.headers
@@ -3317,7 +3321,7 @@ handlePdfIpfsAnswer ctx model form validating kind result =
                                 | error =
                                     Just <|
                                         "PDF upload failed on all selected providers:\n"
-                                            ++ formatUploadFailures failures
+                                            ++ formatUploadFailures ctx.ipfsPreconfig failures
                             }
                   }
                 , Cmd.none
@@ -3375,8 +3379,8 @@ handlePdfIpfsAnswer ctx model form validating kind result =
                 ( model, Cmd.none, Nothing )
 
 
-handleRationaleIpfsAnswer : InnerModel -> StorageForm -> UploadProgress -> ProviderKind -> Result String IpfsAnswer -> ( InnerModel, Cmd msg, Maybe MsgToParent )
-handleRationaleIpfsAnswer model form progress kind result =
+handleRationaleIpfsAnswer : IpfsPreconfig -> InnerModel -> StorageForm -> UploadProgress -> ProviderKind -> Result String IpfsAnswer -> ( InnerModel, Cmd msg, Maybe MsgToParent )
+handleRationaleIpfsAnswer ipfsPreconfig model form progress kind result =
     let
         newProgress =
             recordUploadResult kind result progress
@@ -3398,7 +3402,7 @@ handleRationaleIpfsAnswer model form progress kind result =
                                 | error =
                                     Just <|
                                         "Rationale upload failed on all selected providers:\n"
-                                            ++ formatUploadFailures (List.reverse newProgress.failed)
+                                            ++ formatUploadFailures ipfsPreconfig (List.reverse newProgress.failed)
                             }
                   }
                 , Cmd.none
@@ -3543,7 +3547,7 @@ type alias ViewContext msg =
     , networkId : NetworkId
     , changeNetworkLink : NetworkId -> List (Html msg) -> Html msg
     , signingLink : Transaction -> List { keyName : String, keyHash : Bytes CredentialHash } -> List (Html msg) -> Html msg
-    , ipfsPreconfig : { label : String, description : String }
+    , ipfsPreconfig : IpfsPreconfig
     , voterPreconfig : List PreconfVoter
     , proposalRelationships : Dict String ProposalRelInfo
     }
@@ -4653,13 +4657,16 @@ viewPublishProviderSelection ctx form =
             form.publishSet
     in
     div []
-        [ Html.p [ HA.class "mt-4 mb-2" ]
-            [ text "Pick one or more IPFS providers to publish to. The rationale will be uploaded to every selected provider; the upload succeeds if at least one provider succeeds." ]
-        , Helper.viewGrid 240
-            [ Helper.storageMethodOption ctx.ipfsPreconfig.label s.preconfig (PublishProviderToggled PreconfigKind (not s.preconfig))
-            , Helper.storageMethodOption "Own Blockfrost IPFS" s.blockfrost (PublishProviderToggled BlockfrostKind (not s.blockfrost))
-            , Helper.storageMethodOption "Own NMKR IPFS" s.nmkr (PublishProviderToggled NmkrKind (not s.nmkr))
-            , Helper.storageMethodOption "Custom IPFS server" s.customIpfs (PublishProviderToggled CustomIpfsKind (not s.customIpfs))
+        [ Helper.nestedSurface
+            { heading = "IPFS providers"
+            , sub = "Pick one or more. We upload to each; the step passes if any succeed."
+            }
+            [ Helper.viewGrid 240
+                [ Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig PreconfigKind) s.preconfig (PublishProviderToggled PreconfigKind (not s.preconfig))
+                , Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig BlockfrostKind) s.blockfrost (PublishProviderToggled BlockfrostKind (not s.blockfrost))
+                , Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig NmkrKind) s.nmkr (PublishProviderToggled NmkrKind (not s.nmkr))
+                , Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig CustomIpfsKind) s.customIpfs (PublishProviderToggled CustomIpfsKind (not s.customIpfs))
+                ]
             ]
         , if s.blockfrost then
             viewBlockfrostForm form
@@ -4806,16 +4813,7 @@ viewPublishProviderInfo provider =
 
         BlockfrostIpfs { label, description, projectId } ->
             Helper.storageProviderCard
-                [ Html.h4
-                    [ HA.style "font-weight" "600"
-                    , HA.style "margin-bottom" "0.5rem"
-                    ]
-                    [ text label ]
-                , Html.p
-                    [ HA.style "color" "#4A5568"
-                    , HA.style "font-size" "0.875rem"
-                    ]
-                    [ text description ]
+                [ Helper.storageProviderHeader label description
                 , Helper.storageConfigItem "Project ID"
                     (Html.p
                         [ HA.style "font-family" "monospace"
@@ -4827,16 +4825,7 @@ viewPublishProviderInfo provider =
 
         NmkrIpfs { label, description, userId, apiToken } ->
             Helper.storageProviderCard
-                [ Html.h4
-                    [ HA.style "font-weight" "600"
-                    , HA.style "margin-bottom" "0.5rem"
-                    ]
-                    [ text label ]
-                , Html.p
-                    [ HA.style "color" "#4A5568"
-                    , HA.style "font-size" "0.875rem"
-                    ]
-                    [ text description ]
+                [ Helper.storageProviderHeader label description
                 , Helper.storageConfigItem "User ID"
                     (Html.p
                         [ HA.style "font-family" "monospace"
@@ -4855,16 +4844,7 @@ viewPublishProviderInfo provider =
 
         CustomIpfsProvider { label, description, ipfsServer } ->
             Helper.storageProviderCard
-                [ Html.h4
-                    [ HA.style "font-weight" "600"
-                    , HA.style "margin-bottom" "0.5rem"
-                    ]
-                    [ text label ]
-                , Html.p
-                    [ HA.style "color" "#4A5568"
-                    , HA.style "font-size" "0.875rem"
-                    ]
-                    [ text description ]
+                [ Helper.storageProviderHeader label description
                 , Helper.storageConfigItem "IPFS Server"
                     (Html.a
                         [ HA.href ipfsServer
@@ -4927,7 +4907,7 @@ viewRationaleStep ctx pickProposalStep storageConfigStep step =
                     ]
 
             ( Done _ _, Done _ _, Done form rationale ) ->
-                viewCompletedRationale form.pdfPartialFailures rationale
+                viewCompletedRationale ctx.ipfsPreconfig form.pdfPartialFailures rationale
 
             ( _, Done _ _, _ ) ->
                 div []
@@ -5067,8 +5047,8 @@ viewOneRefForm n reference =
         (ReferenceUriChange n)
 
 
-viewCompletedRationale : List ( ProviderKind, String ) -> Rationale -> Html Msg
-viewCompletedRationale pdfPartialFailures rationale =
+viewCompletedRationale : IpfsPreconfig -> List ( ProviderKind, String ) -> Rationale -> Html Msg
+viewCompletedRationale ipfsPreconfig pdfPartialFailures rationale =
     let
         statementSection =
             div [ HA.style "border-top" "1px solid #EDF2F7", HA.style "padding-top" "1.5rem" ]
@@ -5137,10 +5117,9 @@ viewCompletedRationale pdfPartialFailures rationale =
         , conclusionSection
         , internalVoteSection
         , referencesSection
-        ]
-        [ Helper.viewPartialFailuresWithIntro
-            "PDF was uploaded successfully on at least one provider, but failed on:"
-            (labelProviderFailures pdfPartialFailures)
+        , Helper.viewPartialFailuresWithIntro
+            "Uploaded to some providers, but the following failed:"
+            (labelProviderFailures ipfsPreconfig pdfPartialFailures)
         ]
         EditRationaleButtonClicked
 
@@ -5460,26 +5439,26 @@ viewPermanentStorageStep ctx pickProposalStep rationaleSignatureStep storageConf
                 ( Done _ (StoragePrepublished _), _, Done _ storage ) ->
                     case pickProposalStep of
                         Done _ { id } ->
-                            viewCompletedStorage (Just id) storage
+                            viewCompletedStorage ctx.ipfsPreconfig (Just id) storage
 
                         _ ->
-                            viewCompletedStorage Nothing storage
+                            viewCompletedStorage ctx.ipfsPreconfig Nothing storage
 
                 ( Done _ _, Done _ _, Done _ storage ) ->
                     case pickProposalStep of
                         Done _ { id } ->
-                            viewCompletedStorage (Just id) storage
+                            viewCompletedStorage ctx.ipfsPreconfig (Just id) storage
 
                         _ ->
-                            viewCompletedStorage Nothing storage
+                            viewCompletedStorage ctx.ipfsPreconfig Nothing storage
 
                 _ ->
                     Helper.storageNotAvailableCard
             ]
 
 
-viewCompletedStorage : Maybe ActionId -> Storage -> Html Msg
-viewCompletedStorage maybeActionId { jsonFile, partialFailures } =
+viewCompletedStorage : IpfsPreconfig -> Maybe ActionId -> Storage -> Html Msg
+viewCompletedStorage ipfsPreconfig maybeActionId { jsonFile, partialFailures } =
     let
         fileName =
             case maybeActionId of
@@ -5534,14 +5513,14 @@ viewCompletedStorage maybeActionId { jsonFile, partialFailures } =
             , Html.p [ HA.style "margin" "1rem 0rem" ] [ Helper.downloadJSONButton "Download JSON rationale" { filename = fileName, rawJson = jsonFile.raw } ]
             , Helper.storageInfoGrid infoItems
             ]
-        , Helper.viewPartialFailuresWithIntro "Some IPFS providers failed:" (labelProviderFailures partialFailures)
+        , Helper.viewPartialFailuresWithIntro "Published to some providers, but the following failed:" (labelProviderFailures ipfsPreconfig partialFailures)
         , Helper.viewButton "Change storage location" AddOtherStorageButtonCLicked
         ]
 
 
-labelProviderFailures : List ( ProviderKind, String ) -> List ( String, String )
-labelProviderFailures failures =
-    List.map (\( kind, err ) -> ( providerKindLabel kind, err )) failures
+labelProviderFailures : IpfsPreconfig -> List ( ProviderKind, String ) -> List ( String, String )
+labelProviderFailures ipfsPreconfig failures =
+    List.map (\( kind, err ) -> ( providerKindLabel ipfsPreconfig kind, err )) failures
 
 
 

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -293,11 +293,6 @@ recordUploadResult kind result progress =
             { progress | remaining = remaining, failed = ( kind, transportErr ) :: progress.failed }
 
 
-uploadProgressIsDone : IpfsUploadProgress -> Bool
-uploadProgressIsDone progress =
-    List.isEmpty progress.remaining
-
-
 providerKindLabel : IpfsPreconfig -> ProviderKind -> String
 providerKindLabel ipfsPreconfig kind =
     case kind of
@@ -3296,7 +3291,7 @@ handlePdfIpfsAnswer ctx model form validating kind result =
         rationale =
             validating.rationale
     in
-    if not (uploadProgressIsDone newProgress) then
+    if not (List.isEmpty newProgress.remaining) then
         ( { model | rationaleCreationStep = Validating form { validating | uploads = newProgress } }
         , Cmd.none
         , Nothing
@@ -3377,7 +3372,7 @@ handleRationaleIpfsAnswer ipfsPreconfig model form progress kind result =
         newProgress =
             recordUploadResult kind result progress
     in
-    if not (uploadProgressIsDone newProgress) then
+    if not (List.isEmpty newProgress.remaining) then
         ( { model | permanentStorageStep = Validating form newProgress }
         , Cmd.none
         , Nothing

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -487,44 +487,20 @@ type ProviderKind
     | CustomIpfsKind
 
 
-{-| The set of IPFS providers selected by the user, as boolean flags.
+{-| The set of IPFS providers selected by the user. Membership-tested via
+`List.member`; small (one entry per `ProviderKind`) so the linear scan is fine.
 -}
 type alias PublishSet =
-    { preconfig : Bool
-    , blockfrost : Bool
-    , nmkr : Bool
-    , customIpfs : Bool
-    }
+    List ProviderKind
 
 
-emptyPublishSet : PublishSet
-emptyPublishSet =
-    { preconfig = False
-    , blockfrost = False
-    , nmkr = False
-    , customIpfs = False
-    }
+toggleIpfsProvider : ProviderKind -> PublishSet -> PublishSet
+toggleIpfsProvider kind publishSet =
+    if List.member kind publishSet then
+        List.filter (\k -> k /= kind) publishSet
 
-
-publishSetIsEmpty : PublishSet -> Bool
-publishSetIsEmpty s =
-    not (s.preconfig || s.blockfrost || s.nmkr || s.customIpfs)
-
-
-publishSetSet : ProviderKind -> Bool -> PublishSet -> PublishSet
-publishSetSet kind value s =
-    case kind of
-        PreconfigKind ->
-            { s | preconfig = value }
-
-        BlockfrostKind ->
-            { s | blockfrost = value }
-
-        NmkrKind ->
-            { s | nmkr = value }
-
-        CustomIpfsKind ->
-            { s | customIpfs = value }
+    else
+        kind :: publishSet
 
 
 type alias StorageConfigForm =
@@ -542,7 +518,7 @@ type alias StorageConfigForm =
 initStorageConfigForm : StorageConfigForm
 initStorageConfigForm =
     { mode = ModeIpfs
-    , publishSet = { emptyPublishSet | preconfig = True }
+    , publishSet = [ PreconfigKind ]
     , nmkrUserId = ""
     , nmkrApiToken = ""
     , blockfrostProjectId = ""
@@ -557,41 +533,41 @@ formFromStorageConfig config =
     case config of
         StorageIpfs providers ->
             List.foldl applyProviderToForm
-                { initStorageConfigForm | mode = ModeIpfs, publishSet = emptyPublishSet }
+                { initStorageConfigForm | mode = ModeIpfs, publishSet = [] }
                 providers
 
         StorageCustomHosting ->
-            { initStorageConfigForm | mode = ModeCustomHosting, publishSet = emptyPublishSet }
+            { initStorageConfigForm | mode = ModeCustomHosting, publishSet = [] }
 
         StoragePrepublished ->
-            { initStorageConfigForm | mode = ModePrepublished, publishSet = emptyPublishSet }
+            { initStorageConfigForm | mode = ModePrepublished, publishSet = [] }
 
         StorageNoRationale ->
-            { initStorageConfigForm | mode = ModeNoStorage, publishSet = emptyPublishSet }
+            { initStorageConfigForm | mode = ModeNoStorage, publishSet = [] }
 
 
 applyProviderToForm : IpfsProvider -> StorageConfigForm -> StorageConfigForm
 applyProviderToForm provider form =
     case provider of
         PreconfigIpfs ->
-            { form | publishSet = publishSetSet PreconfigKind True form.publishSet }
+            { form | publishSet = PreconfigKind :: form.publishSet }
 
         BlockfrostIpfs { projectId } ->
             { form
-                | publishSet = publishSetSet BlockfrostKind True form.publishSet
+                | publishSet = BlockfrostKind :: form.publishSet
                 , blockfrostProjectId = projectId
             }
 
         NmkrIpfs { userId, apiToken } ->
             { form
-                | publishSet = publishSetSet NmkrKind True form.publishSet
+                | publishSet = NmkrKind :: form.publishSet
                 , nmkrUserId = userId
                 , nmkrApiToken = apiToken
             }
 
         CustomIpfsProvider { ipfsServer, headers } ->
             { form
-                | publishSet = publishSetSet CustomIpfsKind True form.publishSet
+                | publishSet = CustomIpfsKind :: form.publishSet
                 , ipfsServer = ipfsServer
                 , headers = headers
             }
@@ -898,7 +874,7 @@ type Msg
     | GotCip100Verification String (Result Http.Error Api.Cip100VerificationResponse)
       -- Storage Config Step
     | StorageModeSelected StorageMode
-    | IpfsProviderToggled ProviderKind Bool
+    | IpfsProviderToggled ProviderKind
     | BlockfrostProjectIdChange String
     | NmkrUserIdChange String
     | NmkrApiTokenChange String
@@ -1282,9 +1258,9 @@ innerUpdate ctx msg model =
             , Nothing
             )
 
-        IpfsProviderToggled kind value ->
+        IpfsProviderToggled kind ->
             ( updateStorageConfigForm
-                (\form -> { form | publishSet = publishSetSet kind value form.publishSet })
+                (\form -> { form | publishSet = toggleIpfsProvider kind form.publishSet })
                 model
             , Cmd.none
             , Nothing
@@ -2498,8 +2474,8 @@ validateIpfsForm form =
             Ok StorageNoRationale
 
         ModeIpfs ->
-            if publishSetIsEmpty form.publishSet then
-                Err "Please select at least one IPFS provider, or pick another mode."
+            if List.isEmpty form.publishSet then
+                Err "Please select at least one IPFS provider, or pick another kind of rationale storage."
 
             else
                 buildIpfsProviders form
@@ -2509,77 +2485,63 @@ validateIpfsForm form =
 buildIpfsProviders : StorageConfigForm -> Result String (List IpfsProvider)
 buildIpfsProviders form =
     let
-        s =
-            form.publishSet
+        buildProvider kind =
+            case kind of
+                PreconfigKind ->
+                    Ok PreconfigIpfs
 
-        addPreconfig acc =
-            if s.preconfig then
-                Ok (PreconfigIpfs :: acc)
+                BlockfrostKind ->
+                    case String.trim form.blockfrostProjectId of
+                        "" ->
+                            Err "Missing blockfrost project id"
 
-            else
-                Ok acc
+                        projectId ->
+                            Ok (BlockfrostIpfs { projectId = projectId })
 
-        addBlockfrost acc =
-            if s.blockfrost then
-                case String.trim form.blockfrostProjectId of
-                    "" ->
-                        Err "Missing blockfrost project id"
+                NmkrKind ->
+                    case String.trim form.nmkrUserId of
+                        "" ->
+                            Err "Missing nmkr user id"
 
-                    projectId ->
-                        Ok (BlockfrostIpfs { projectId = projectId } :: acc)
+                        userId ->
+                            Ok (NmkrIpfs { userId = userId, apiToken = form.nmkrApiToken })
 
-            else
-                Ok acc
-
-        addNmkr acc =
-            if s.nmkr then
-                case String.trim form.nmkrUserId of
-                    "" ->
-                        Err "Missing nmkr user id"
-
-                    userId ->
-                        Ok (NmkrIpfs { userId = userId, apiToken = form.nmkrApiToken } :: acc)
-
-            else
-                Ok acc
-
-        addCustomIpfs acc =
-            if s.customIpfs then
-                let
-                    ipfsServerUrlSeemsLegit =
-                        case Url.fromString form.ipfsServer of
-                            Just _ ->
-                                Ok ()
-
-                            Nothing ->
-                                Err ("This url seems incorrect, it must look like this: https://subdomain.domain.org, instead I got this: " ++ form.ipfsServer)
-
-                    nonEmptyHeadersResult =
-                        if List.any (\( f, _ ) -> String.isEmpty f) form.headers then
-                            Err "Empty header fields are forbidden."
-
-                        else
-                            Ok ()
-                in
-                ipfsServerUrlSeemsLegit
-                    |> Result.andThen (\_ -> nonEmptyHeadersResult)
-                    |> Result.map
-                        (\_ ->
-                            CustomIpfsProvider
-                                { ipfsServer = form.ipfsServer
-                                , headers = form.headers
-                                }
-                                :: acc
-                        )
-
-            else
-                Ok acc
+                CustomIpfsKind ->
+                    buildCustomIpfsProvider form
     in
-    addPreconfig []
-        |> Result.andThen addBlockfrost
-        |> Result.andThen addNmkr
-        |> Result.andThen addCustomIpfs
-        |> Result.map List.reverse
+    List.foldr
+        (\kind acc -> Result.map2 (::) (buildProvider kind) acc)
+        (Ok [])
+        form.publishSet
+
+
+buildCustomIpfsProvider : StorageConfigForm -> Result String IpfsProvider
+buildCustomIpfsProvider form =
+    let
+        urlOk =
+            case Url.fromString form.ipfsServer of
+                Just _ ->
+                    Ok ()
+
+                Nothing ->
+                    Err ("This url seems incorrect, it must look like this: https://subdomain.domain.org, instead I got this: " ++ form.ipfsServer)
+
+        headersOk =
+            if List.any (\( f, _ ) -> String.isEmpty f) form.headers then
+                Err "Empty header fields are forbidden."
+
+            else
+                Ok ()
+    in
+    Result.map2
+        (\_ _ ->
+            CustomIpfsProvider
+                { ipfsServer = form.ipfsServer
+                , headers = form.headers
+                }
+        )
+        urlOk
+        headersOk
 
 
 
@@ -4640,37 +4602,36 @@ viewStorageConfigStep ctx step =
 viewIpfsProviderSelection : ViewContext msg -> StorageConfigForm -> Html Msg
 viewIpfsProviderSelection ctx form =
     let
-        s =
-            form.publishSet
-    in
-    div []
-        [ Helper.nestedCard
-            { heading = "IPFS providers"
-            , sub = "Pick one or more. We upload to each; the step passes if any succeed."
-            }
-            [ Helper.viewGrid 240
-                [ Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig PreconfigKind) s.preconfig (IpfsProviderToggled PreconfigKind (not s.preconfig))
-                , Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig BlockfrostKind) s.blockfrost (IpfsProviderToggled BlockfrostKind (not s.blockfrost))
-                , Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig NmkrKind) s.nmkr (IpfsProviderToggled NmkrKind (not s.nmkr))
-                , Helper.storageMethodCheckbox (providerKindLabel ctx.ipfsPreconfig CustomIpfsKind) s.customIpfs (IpfsProviderToggled CustomIpfsKind (not s.customIpfs))
+        checkbox kind =
+            Helper.storageMethodCheckbox
+                (providerKindLabel ctx.ipfsPreconfig kind)
+                (List.member kind form.publishSet)
+                (IpfsProviderToggled kind)
+
+        providerCards =
+            Helper.nestedCard
+                { heading = "IPFS providers"
+                , sub = "Pick one or more. We upload to each. The step passes if any succeed."
+                }
+                [ Helper.viewGrid 240 <|
+                    List.map checkbox [ PreconfigKind, BlockfrostKind, NmkrKind, CustomIpfsKind ]
                 ]
-            ]
-        , if s.blockfrost then
-            viewBlockfrostForm form
 
-          else
-            text ""
-        , if s.nmkr then
-            viewNmkrForm form
+        providerConfig kind =
+            case kind of
+                BlockfrostKind ->
+                    Just <| viewBlockfrostForm form
 
-          else
-            text ""
-        , if s.customIpfs then
-            viewCustomIpfsForm form
+                NmkrKind ->
+                    Just <| viewNmkrForm form
 
-          else
-            text ""
-        ]
+                CustomIpfsKind ->
+                    Just <| viewCustomIpfsForm form
+
+                _ ->
+                    Nothing
+    in
+    div [] (providerCards :: List.filterMap providerConfig form.publishSet)
 
 
 viewBlockfrostForm : StorageConfigForm -> Html Msg

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -4461,7 +4461,7 @@ viewStorageConfigStep ctx step =
                     , Html.p [ HA.class "mb-4" ]
                         [ text "Only a link to your rationale is stored on Cardano,"
                         , text " so it's recommended to store the actual file containing the text in a permanent storage solution."
-                        , text " Pick one of the modes below."
+                        , text " Pick one of the below options for storing your rationale."
                         ]
                     , Helper.storageConfigCard "Storage Mode"
                         [ Helper.viewGrid 240

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -276,6 +276,9 @@ initUploadProgress kinds =
 recordUploadResult : ProviderKind -> Result String IpfsAnswer -> UploadProgress -> UploadProgress
 recordUploadResult kind result progress =
     let
+        -- Assumes a single entry per ProviderKind in `remaining`. The form
+        -- enforces this today (one toggle per kind); if that ever changes,
+        -- this filter would clear all duplicates at once.
         remaining =
             List.filter ((/=) kind) progress.remaining
     in
@@ -4838,7 +4841,7 @@ viewPublishProviderInfo provider =
                         [ HA.style "font-family" "monospace"
                         , HA.style "word-break" "break-all"
                         ]
-                        [ text (maskToken apiToken) ]
+                        [ text (String.left 4 apiToken ++ "…" ++ String.right 4 apiToken) ]
                     )
                 ]
 
@@ -4857,14 +4860,6 @@ viewPublishProviderInfo provider =
                     )
                 ]
 
-
-maskToken : String -> String
-maskToken token =
-    if String.length token <= 12 then
-        String.repeat (String.length token) "•"
-
-    else
-        String.left 4 token ++ "…" ++ String.right 4 token
 
 
 

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -25,7 +25,7 @@ The steps are sequential but allow going back to modify previous steps.
 
 -}
 
-import Api exposing (ActiveProposal, AuthorVerification, CcInfo, DrepInfo, IpfsAnswer(..), OnchainVote, PoolInfo)
+import Api exposing (ActiveProposal, AuthorVerification, CcInfo, DrepInfo, IpfsAnswer(..), IpfsFile, OnchainVote, PoolInfo)
 import Blake2b256
 import Browser.Dom as Dom
 import Bytes as ElmBytes
@@ -92,9 +92,9 @@ type alias InnerModel =
     , voterStep : Step VoterPreparationForm Witness.Voter Witness.Voter
     , pickProposalStep : Step {} {} ActiveProposal
     , storageConfigStep : Step StorageConfigForm {} StorageConfig
-    , rationaleCreationStep : Step RationaleForm Rationale Rationale
+    , rationaleCreationStep : Step RationaleForm RationaleValidating Rationale
     , rationaleSignatureStep : Step RationaleSignatureForm {} RationaleSignature
-    , permanentStorageStep : Step StorageForm {} Storage
+    , permanentStorageStep : Step StorageForm UploadProgress Storage
     , buildTxStep : Step BuildTxPrep {} {}
     , visibleProposalCount : Int
     , showCartToast : Bool
@@ -135,7 +135,7 @@ init ipfsPreconfig =
         , reloadedLastVoter = False
         , voterStep = Preparing initVoterForm
         , pickProposalStep = Preparing {}
-        , storageConfigStep = Done (initStorageConfigForm ipfsPreconfig) (UsePreconfigIpfs ipfsPreconfig)
+        , storageConfigStep = Done initStorageConfigForm (StoragePublish [ PreconfigIpfs ipfsPreconfig ])
         , rationaleCreationStep = Preparing initRationaleForm
         , rationaleSignatureStep = Preparing initRationaleSignatureForm
         , permanentStorageStep = Preparing initStorageForm
@@ -200,6 +200,7 @@ type alias RationaleForm =
     , internalVote : InternalVote
     , references : List Reference
     , error : Maybe String
+    , pdfPartialFailures : List ( ProviderKind, String )
     }
 
 
@@ -238,6 +239,7 @@ initRationaleForm =
     , internalVote = noInternalVote
     , references = []
     , error = Nothing
+    , pdfPartialFailures = []
     }
 
 
@@ -249,6 +251,80 @@ type alias Rationale =
     , conclusion : Maybe String
     , internalVote : InternalVote
     , references : List Reference
+    }
+
+
+{-| Tracks the progress of fan-out IPFS uploads across multiple publish providers.
+-}
+type alias UploadProgress =
+    { remaining : List ProviderKind
+    , succeeded : List ( ProviderKind, IpfsFile )
+    , failed : List ( ProviderKind, String )
+    }
+
+
+emptyUploadProgress : UploadProgress
+emptyUploadProgress =
+    { remaining = [], succeeded = [], failed = [] }
+
+
+initUploadProgress : List ProviderKind -> UploadProgress
+initUploadProgress kinds =
+    { remaining = kinds, succeeded = [], failed = [] }
+
+
+recordUploadResult : ProviderKind -> Result String IpfsAnswer -> UploadProgress -> UploadProgress
+recordUploadResult kind result progress =
+    let
+        remaining =
+            List.filter ((/=) kind) progress.remaining
+    in
+    case result of
+        Ok (IpfsAddSuccessful file) ->
+            { progress | remaining = remaining, succeeded = ( kind, file ) :: progress.succeeded }
+
+        Ok (IpfsError msg) ->
+            { progress | remaining = remaining, failed = ( kind, msg ) :: progress.failed }
+
+        Err transportErr ->
+            { progress | remaining = remaining, failed = ( kind, transportErr ) :: progress.failed }
+
+
+uploadProgressIsDone : UploadProgress -> Bool
+uploadProgressIsDone progress =
+    List.isEmpty progress.remaining
+
+
+providerKindLabel : ProviderKind -> String
+providerKindLabel kind =
+    case kind of
+        PreconfigKind ->
+            "Preconfigured IPFS"
+
+        BlockfrostKind ->
+            "Blockfrost IPFS"
+
+        NmkrKind ->
+            "NMKR IPFS"
+
+        CustomIpfsKind ->
+            "Custom IPFS"
+
+
+formatUploadFailures : List ( ProviderKind, String ) -> String
+formatUploadFailures failures =
+    failures
+        |> List.map (\( kind, err ) -> providerKindLabel kind ++ ": " ++ err)
+        |> String.join "\n"
+
+
+{-| Validating state for the rationale creation step. While the PDF is being
+auto-generated and uploaded, we keep both the rationale being validated
+and the per-provider upload progress.
+-}
+type alias RationaleValidating =
+    { rationale : Rationale
+    , uploads : UploadProgress
     }
 
 
@@ -341,18 +417,70 @@ initAuthorForm =
 -- Storage Step
 
 
-type StorageMethod
-    = PreconfigIPFS { label : String, description : String }
-    | NmkrIPFS
-    | BlockfrostIPFS
-    | CustomIPFS
-    | CustomHosting
-    | CustomPrepublished
-    | NoStorage
+{-| The user's "primary mode" choice for the storage step. This is exclusive:
+the rationale is either published to IPFS, hosted manually by the user,
+already published, or absent.
+-}
+type StorageMode
+    = ModePublish
+    | ModeCustomHosting
+    | ModePrepublished
+    | ModeNoStorage
+
+
+{-| Identifies an IPFS publish provider. Used as a key for tracking selection,
+upload progress, and per-provider error reporting.
+-}
+type ProviderKind
+    = PreconfigKind
+    | BlockfrostKind
+    | NmkrKind
+    | CustomIpfsKind
+
+
+{-| The set of IPFS providers selected by the user, as boolean flags.
+-}
+type alias PublishSet =
+    { preconfig : Bool
+    , blockfrost : Bool
+    , nmkr : Bool
+    , customIpfs : Bool
+    }
+
+
+emptyPublishSet : PublishSet
+emptyPublishSet =
+    { preconfig = False
+    , blockfrost = False
+    , nmkr = False
+    , customIpfs = False
+    }
+
+
+publishSetIsEmpty : PublishSet -> Bool
+publishSetIsEmpty s =
+    not (s.preconfig || s.blockfrost || s.nmkr || s.customIpfs)
+
+
+publishSetSet : ProviderKind -> Bool -> PublishSet -> PublishSet
+publishSetSet kind value s =
+    case kind of
+        PreconfigKind ->
+            { s | preconfig = value }
+
+        BlockfrostKind ->
+            { s | blockfrost = value }
+
+        NmkrKind ->
+            { s | nmkr = value }
+
+        CustomIpfsKind ->
+            { s | customIpfs = value }
 
 
 type alias StorageConfigForm =
-    { storageMethod : StorageMethod
+    { mode : StorageMode
+    , publishSet : PublishSet
     , nmkrUserId : String
     , nmkrApiToken : String
     , blockfrostProjectId : String
@@ -362,14 +490,10 @@ type alias StorageConfigForm =
     }
 
 
-initStorageConfigForm : { label : String, description : String } -> StorageConfigForm
-initStorageConfigForm ipfsPreconfig =
-    initStorageConfigFormWithMethod <| PreconfigIPFS ipfsPreconfig
-
-
-initStorageConfigFormWithMethod : StorageMethod -> StorageConfigForm
-initStorageConfigFormWithMethod method =
-    { storageMethod = method
+initStorageConfigForm : StorageConfigForm
+initStorageConfigForm =
+    { mode = ModePublish
+    , publishSet = { emptyPublishSet | preconfig = True }
     , nmkrUserId = ""
     , nmkrApiToken = ""
     , blockfrostProjectId = ""
@@ -382,112 +506,162 @@ initStorageConfigFormWithMethod method =
 formFromStorageConfig : StorageConfig -> StorageConfigForm
 formFromStorageConfig config =
     case config of
-        UsePreconfigIpfs preconfig ->
-            initStorageConfigForm preconfig
+        StoragePublish providers ->
+            List.foldl applyProviderToForm
+                { initStorageConfigForm | mode = ModePublish, publishSet = emptyPublishSet }
+                providers
 
-        UseBlockfrostIpfs { projectId } ->
-            let
-                form =
-                    initStorageConfigFormWithMethod BlockfrostIPFS
-            in
-            { form | blockfrostProjectId = projectId }
+        StorageCustomHosting _ ->
+            { initStorageConfigForm | mode = ModeCustomHosting, publishSet = emptyPublishSet }
 
-        UseNmkrIpfs { userId, apiToken } ->
-            let
-                form =
-                    initStorageConfigFormWithMethod NmkrIPFS
-            in
-            { form | nmkrUserId = userId, nmkrApiToken = apiToken }
+        StoragePrepublished _ ->
+            { initStorageConfigForm | mode = ModePrepublished, publishSet = emptyPublishSet }
 
-        UseCustomIpfs { ipfsServer, headers } ->
-            let
-                form =
-                    initStorageConfigFormWithMethod CustomIPFS
-            in
-            { form | ipfsServer = ipfsServer, headers = headers }
+        StorageNoRationale _ ->
+            { initStorageConfigForm | mode = ModeNoStorage, publishSet = emptyPublishSet }
 
-        UseCustomHosting _ ->
-            initStorageConfigFormWithMethod CustomHosting
 
-        UseCustomPrepublished _ ->
-            initStorageConfigFormWithMethod CustomPrepublished
+applyProviderToForm : PublishProvider -> StorageConfigForm -> StorageConfigForm
+applyProviderToForm provider form =
+    case provider of
+        PreconfigIpfs _ ->
+            { form | publishSet = publishSetSet PreconfigKind True form.publishSet }
 
-        UseNoStorage _ ->
-            initStorageConfigFormWithMethod NoStorage
+        BlockfrostIpfs { projectId } ->
+            { form
+                | publishSet = publishSetSet BlockfrostKind True form.publishSet
+                , blockfrostProjectId = projectId
+            }
+
+        NmkrIpfs { userId, apiToken } ->
+            { form
+                | publishSet = publishSetSet NmkrKind True form.publishSet
+                , nmkrUserId = userId
+                , nmkrApiToken = apiToken
+            }
+
+        CustomIpfsProvider { ipfsServer, headers } ->
+            { form
+                | publishSet = publishSetSet CustomIpfsKind True form.publishSet
+                , ipfsServer = ipfsServer
+                , headers = headers
+            }
+
+
+{-| One of the IPFS providers the rationale can be published to.
+-}
+type PublishProvider
+    = PreconfigIpfs { label : String, description : String }
+    | BlockfrostIpfs { label : String, description : String, projectId : String }
+    | NmkrIpfs { label : String, description : String, userId : String, apiToken : String }
+    | CustomIpfsProvider { label : String, description : String, ipfsServer : String, headers : List ( String, String ) }
+
+
+providerKind : PublishProvider -> ProviderKind
+providerKind provider =
+    case provider of
+        PreconfigIpfs _ ->
+            PreconfigKind
+
+        BlockfrostIpfs _ ->
+            BlockfrostKind
+
+        NmkrIpfs _ ->
+            NmkrKind
+
+        CustomIpfsProvider _ ->
+            CustomIpfsKind
 
 
 type StorageConfig
-    = UsePreconfigIpfs { label : String, description : String }
-    | UseBlockfrostIpfs { label : String, description : String, projectId : String }
-    | UseNmkrIpfs { label : String, description : String, userId : String, apiToken : String }
-    | UseCustomIpfs { label : String, description : String, ipfsServer : String, headers : List ( String, String ) }
-    | UseCustomHosting { label : String, description : String }
-    | UseCustomPrepublished { label : String, description : String }
-    | UseNoStorage { label : String, description : String }
+    = StoragePublish (List PublishProvider)
+    | StorageCustomHosting { label : String, description : String }
+    | StoragePrepublished { label : String, description : String }
+    | StorageNoRationale { label : String, description : String }
+
+
+storedProviders : StorageConfig -> List PublishProvider
+storedProviders config =
+    case config of
+        StoragePublish providers ->
+            providers
+
+        _ ->
+            []
 
 
 {-| Initialize the default storage config.
 -}
 initStorageConfig : { label : String, description : String } -> StorageConfig
 initStorageConfig { label, description } =
-    UsePreconfigIpfs { label = label, description = description }
+    StoragePublish [ PreconfigIpfs { label = label, description = description } ]
 
 
 encodeStorageConfig : StorageConfig -> JE.Value
 encodeStorageConfig config =
     case config of
-        UsePreconfigIpfs { label, description } ->
+        StoragePublish providers ->
             JE.object
-                [ ( "storageType", JE.string "UsePreconfigIpfs" )
+                [ ( "kind", JE.string "StoragePublish" )
+                , ( "providers", JE.list encodePublishProvider providers )
+                ]
+
+        StorageCustomHosting { label, description } ->
+            JE.object
+                [ ( "kind", JE.string "StorageCustomHosting" )
                 , ( "label", JE.string label )
                 , ( "description", JE.string description )
                 ]
 
-        UseBlockfrostIpfs { label, description, projectId } ->
+        StoragePrepublished { label, description } ->
             JE.object
-                [ ( "storageType", JE.string "UseBlockfrostIpfs" )
+                [ ( "kind", JE.string "StoragePrepublished" )
+                , ( "label", JE.string label )
+                , ( "description", JE.string description )
+                ]
+
+        StorageNoRationale { label, description } ->
+            JE.object
+                [ ( "kind", JE.string "StorageNoRationale" )
+                , ( "label", JE.string label )
+                , ( "description", JE.string description )
+                ]
+
+
+encodePublishProvider : PublishProvider -> JE.Value
+encodePublishProvider provider =
+    case provider of
+        PreconfigIpfs { label, description } ->
+            JE.object
+                [ ( "type", JE.string "PreconfigIpfs" )
+                , ( "label", JE.string label )
+                , ( "description", JE.string description )
+                ]
+
+        BlockfrostIpfs { label, description, projectId } ->
+            JE.object
+                [ ( "type", JE.string "BlockfrostIpfs" )
                 , ( "label", JE.string label )
                 , ( "description", JE.string description )
                 , ( "projectId", JE.string projectId )
                 ]
 
-        UseNmkrIpfs { label, description, userId, apiToken } ->
+        NmkrIpfs { label, description, userId, apiToken } ->
             JE.object
-                [ ( "storageType", JE.string "UseNmkrIpfs" )
+                [ ( "type", JE.string "NmkrIpfs" )
                 , ( "label", JE.string label )
                 , ( "description", JE.string description )
                 , ( "userId", JE.string userId )
                 , ( "apiToken", JE.string apiToken )
                 ]
 
-        UseCustomIpfs { label, description, ipfsServer, headers } ->
+        CustomIpfsProvider { label, description, ipfsServer, headers } ->
             JE.object
-                [ ( "storageType", JE.string "UseCustomIpfs" )
+                [ ( "type", JE.string "CustomIpfs" )
                 , ( "label", JE.string label )
                 , ( "description", JE.string description )
                 , ( "ipfsServer", JE.string ipfsServer )
                 , ( "headers", JE.list encodeHttpHeader headers )
-                ]
-
-        UseCustomHosting { label, description } ->
-            JE.object
-                [ ( "storageType", JE.string "UseCustomHosting" )
-                , ( "label", JE.string label )
-                , ( "description", JE.string description )
-                ]
-
-        UseCustomPrepublished { label, description } ->
-            JE.object
-                [ ( "storageType", JE.string "UseCustomPrepublished" )
-                , ( "label", JE.string label )
-                , ( "description", JE.string description )
-                ]
-
-        UseNoStorage { label, description } ->
-            JE.object
-                [ ( "storageType", JE.string "UseNoStorage" )
-                , ( "label", JE.string label )
-                , ( "description", JE.string description )
                 ]
 
 
@@ -505,52 +679,67 @@ httpHeaderDecoder =
 
 storageConfigDecoder : JD.Decoder StorageConfig
 storageConfigDecoder =
-    JD.field "storageType" JD.string
+    JD.field "kind" JD.string
         |> JD.andThen
-            (\storageType ->
-                case storageType of
-                    "UsePreconfigIpfs" ->
-                        JD.map2 (\label description -> UsePreconfigIpfs { label = label, description = description })
+            (\kind ->
+                case kind of
+                    "StoragePublish" ->
+                        JD.field "providers" (JD.list publishProviderDecoder)
+                            |> JD.map StoragePublish
+
+                    "StorageCustomHosting" ->
+                        JD.map2 (\label description -> StorageCustomHosting { label = label, description = description })
                             (JD.field "label" JD.string)
                             (JD.field "description" JD.string)
 
-                    "UseBlockfrostIpfs" ->
-                        JD.map3 (\label description projectId -> UseBlockfrostIpfs { label = label, description = description, projectId = projectId })
+                    "StoragePrepublished" ->
+                        JD.map2 (\label description -> StoragePrepublished { label = label, description = description })
+                            (JD.field "label" JD.string)
+                            (JD.field "description" JD.string)
+
+                    "StorageNoRationale" ->
+                        JD.map2 (\label description -> StorageNoRationale { label = label, description = description })
+                            (JD.field "label" JD.string)
+                            (JD.field "description" JD.string)
+
+                    _ ->
+                        JD.fail ("Unknown storage kind: " ++ kind)
+            )
+
+
+publishProviderDecoder : JD.Decoder PublishProvider
+publishProviderDecoder =
+    JD.field "type" JD.string
+        |> JD.andThen
+            (\providerType ->
+                case providerType of
+                    "PreconfigIpfs" ->
+                        JD.map2 (\label description -> PreconfigIpfs { label = label, description = description })
+                            (JD.field "label" JD.string)
+                            (JD.field "description" JD.string)
+
+                    "BlockfrostIpfs" ->
+                        JD.map3 (\label description projectId -> BlockfrostIpfs { label = label, description = description, projectId = projectId })
                             (JD.field "label" JD.string)
                             (JD.field "description" JD.string)
                             (JD.field "projectId" JD.string)
 
-                    "UseNmkrIpfs" ->
-                        JD.map4 (\label description userId apiToken -> UseNmkrIpfs { label = label, description = description, userId = userId, apiToken = apiToken })
+                    "NmkrIpfs" ->
+                        JD.map4 (\label description userId apiToken -> NmkrIpfs { label = label, description = description, userId = userId, apiToken = apiToken })
                             (JD.field "label" JD.string)
                             (JD.field "description" JD.string)
                             (JD.field "userId" JD.string)
                             (JD.field "apiToken" JD.string)
 
-                    "UseCustomIpfs" ->
-                        JD.map4 (\label description ipfsServer headers -> UseCustomIpfs { label = label, description = description, ipfsServer = ipfsServer, headers = headers })
+                    "CustomIpfs" ->
+                        JD.map4 (\label description ipfsServer headers -> CustomIpfsProvider { label = label, description = description, ipfsServer = ipfsServer, headers = headers })
                             (JD.field "label" JD.string)
                             (JD.field "description" JD.string)
                             (JD.field "ipfsServer" JD.string)
                             (JD.field "headers" (JD.list httpHeaderDecoder))
 
-                    "UseCustomHosting" ->
-                        JD.map2 (\label description -> UseCustomHosting { label = label, description = description })
-                            (JD.field "label" JD.string)
-                            (JD.field "description" JD.string)
-
-                    "UseCustomPrepublished" ->
-                        JD.map2 (\label description -> UseCustomPrepublished { label = label, description = description })
-                            (JD.field "label" JD.string)
-                            (JD.field "description" JD.string)
-
-                    "UseNoStorage" ->
-                        JD.map2 (\label description -> UseNoStorage { label = label, description = description })
-                            (JD.field "label" JD.string)
-                            (JD.field "description" JD.string)
-
                     _ ->
-                        JD.fail "Unknown storage type"
+                        JD.fail ("Unknown provider type: " ++ providerType)
             )
 
 
@@ -569,6 +758,7 @@ initStorageForm =
 
 type alias Storage =
     { jsonFile : UploadedFile
+    , partialFailures : List ( ProviderKind, String )
     }
 
 
@@ -691,7 +881,8 @@ type Msg
     | ShowMoreProposals Int
     | GotCip100Verification String (Result Http.Error Api.Cip100VerificationResponse)
       -- Storage Config Step
-    | StorageMethodSelected StorageMethod
+    | StorageModeSelected StorageMode
+    | PublishProviderToggled ProviderKind Bool
     | BlockfrostProjectIdChange String
     | NmkrUserIdChange String
     | NmkrApiTokenChange String
@@ -736,7 +927,7 @@ type Msg
     | ChangeAuthorsButtonClicked
       -- Rationale Storage
     | PinJsonIpfsButtonClicked
-    | GotIpfsAnswer (Result String IpfsAnswer)
+    | GotIpfsAnswer ProviderKind (Result String IpfsAnswer)
     | PublishedRationaleUriChanged String
     | CheckRationaleUrlButtonClicked
     | AddOtherStorageButtonCLicked
@@ -776,6 +967,7 @@ type alias UpdateContext msg =
     , constitutionUri : Maybe String
     , networkId : NetworkId
     , authorPreconfig : List PreconfAuthor
+    , ipfsPreconfig : { label : String, description : String }
     }
 
 
@@ -1003,7 +1195,7 @@ innerUpdate ctx msg model =
                                 -- Reset the rationale if it is not "pre-published"
                                 resetRationaleModel =
                                     case model.storageConfigStep of
-                                        Done _ (UseCustomPrepublished _) ->
+                                        Done _ (StoragePrepublished _) ->
                                             model
 
                                         _ ->
@@ -1064,8 +1256,16 @@ innerUpdate ctx msg model =
         --
         -- Vote Rationale Storage Configuration Step
         --
-        StorageMethodSelected method ->
-            ( updateStorageConfigForm (\form -> { form | storageMethod = method }) model
+        StorageModeSelected mode ->
+            ( updateStorageConfigForm (\form -> { form | mode = mode }) model
+            , Cmd.none
+            , Nothing
+            )
+
+        PublishProviderToggled kind value ->
+            ( updateStorageConfigForm
+                (\form -> { form | publishSet = publishSetSet kind value form.publishSet })
+                model
             , Cmd.none
             , Nothing
             )
@@ -1121,7 +1321,7 @@ innerUpdate ctx msg model =
         ValidateStorageConfigButtonClicked ->
             case model.storageConfigStep of
                 Preparing form ->
-                    case validateIpfsForm form of
+                    case validateIpfsForm ctx.ipfsPreconfig form of
                         Ok storageConfig ->
                             -- TODO: test some endpoint to check custom config validity,
                             -- and return a "Validating" step instead of a "Done" step.
@@ -1302,15 +1502,15 @@ innerUpdate ctx msg model =
                 -- If validation partially succeeds but needs more processing,
                 -- it will return in the Preparing step and we now need to store the PDF on IPFS,
                 -- and then edit the rationale to include the PDF link
-                ( Validating form rationale, Done _ { id } ) ->
+                ( Validating form validating, Done _ { id } ) ->
                     let
                         tempUnsignedRationaleForm =
-                            rationaleSignatureFromForm ctx.jsonLdContexts id { authors = [], error = Nothing, rationale = rationale }
+                            rationaleSignatureFromForm ctx.jsonLdContexts id { authors = [], error = Nothing, rationale = validating.rationale }
 
                         rawFileContent =
                             tempUnsignedRationaleForm.signedJson
                     in
-                    ( { model | rationaleCreationStep = Validating form rationale }
+                    ( { model | rationaleCreationStep = Validating form validating }
                       -- Save rationale PDF to IPFS and update rationale with link
                     , Api.defaultApiProvider.convertToPdf rawFileContent GotUnsignedPdfFile
                         |> Cmd.map ctx.wrapMsg
@@ -1447,39 +1647,17 @@ innerUpdate ctx msg model =
                 _ ->
                     ( model, Cmd.none, Nothing )
 
-        GotIpfsAnswer (Err httpError) ->
+        GotIpfsAnswer kind result ->
             case ( model.rationaleCreationStep, model.permanentStorageStep ) of
-                -- If we are validating the rationale form, it means the IPFS answer
-                -- is most likely the PDF we got back for PDF auto-gen.
-                ( Validating form _, _ ) ->
-                    ( { model | rationaleCreationStep = Preparing { form | error = Just <| Debug.toString httpError } }
-                    , Cmd.none
-                    , Nothing
-                    )
+                -- If we are validating the rationale form, the IPFS answer
+                -- is for the PDF auto-gen upload.
+                ( Validating form validating, _ ) ->
+                    handlePdfIpfsAnswer ctx model form validating kind result
 
-                -- Otherwise, if we are validating the permanent storage step, it means the IPFS answer
-                -- is most likely for the signed JSON rationale.
-                ( _, Validating form _ ) ->
-                    ( { model | permanentStorageStep = Preparing { form | error = Just <| Debug.toString httpError } }
-                    , Cmd.none
-                    , Nothing
-                    )
-
-                -- Any other case is not supposed to happen.
-                _ ->
-                    ( model, Cmd.none, Nothing )
-
-        GotIpfsAnswer (Ok ipfsAnswer) ->
-            case ( model.rationaleCreationStep, model.permanentStorageStep ) of
-                -- If we are validating the rationale form, it means the IPFS answer
-                -- is most likely the PDF we got back for PDF auto-gen.
-                ( Validating form rationale, _ ) ->
-                    handlePdfIpfsAnswer ctx model form rationale ipfsAnswer
-
-                -- Otherwise, if we are validating the permanent storage step, it means the IPFS answer
-                -- is most likely for the signed JSON rationale.
-                ( _, Validating form _ ) ->
-                    handleRationaleIpfsAnswer model form ipfsAnswer
+                -- Otherwise, if we are validating the permanent storage step, the IPFS answer
+                -- is for the signed JSON rationale upload.
+                ( _, Validating form progress ) ->
+                    handleRationaleIpfsAnswer model form progress kind result
 
                 _ ->
                     ( model, Cmd.none, Nothing )
@@ -1502,7 +1680,7 @@ innerUpdate ctx msg model =
                         let
                             raw =
                                 case ( storageConfig, model.rationaleSignatureStep ) of
-                                    ( UseCustomHosting _, Done _ { signedJson } ) ->
+                                    ( StorageCustomHosting _, Done _ { signedJson } ) ->
                                         Just signedJson
 
                                     _ ->
@@ -1513,7 +1691,7 @@ innerUpdate ctx msg model =
                                     |> ConcurrentTask.toResult
                                     |> ConcurrentTask.map (GotRawPublishedRationaleTask { raw = raw })
                         in
-                        ( { model | permanentStorageStep = Validating form {} }
+                        ( { model | permanentStorageStep = Validating form emptyUploadProgress }
                         , Cmd.none
                         , Just (RunTask task)
                         )
@@ -1740,7 +1918,7 @@ handleTaskCompleted task (Model model) =
                                         |> Bytes.fromHexUnchecked
                                 }
                         in
-                        ( Model { model | permanentStorageStep = Done { form | error = Nothing } { jsonFile = uploadedFile } }
+                        ( Model { model | permanentStorageStep = Done { form | error = Nothing } { jsonFile = uploadedFile, partialFailures = [] } }
                         , Cmd.none
                         , Nothing
                         )
@@ -2287,91 +2465,130 @@ updateStorageConfigForm formUpdate model =
             model
 
 
-validateIpfsForm : StorageConfigForm -> Result String StorageConfig
-validateIpfsForm form =
-    case form.storageMethod of
-        -- For standard IPFS, no validation needed
-        PreconfigIPFS { label, description } ->
-            Ok (UsePreconfigIpfs { label = label, description = description })
-
-        BlockfrostIPFS ->
-            case String.trim form.blockfrostProjectId of
-                "" ->
-                    Err "Missing blockfrost project id"
-
-                projectId ->
-                    Ok <|
-                        UseBlockfrostIpfs
-                            { label = "Own Blockfrost IPFS"
-                            , description = "Using Blockfrost IPFS server to store your files."
-                            , projectId = projectId
-                            }
-
-        NmkrIPFS ->
-            case String.trim form.nmkrUserId of
-                "" ->
-                    Err "Missing nmkr user id"
-
-                userId ->
-                    Ok <|
-                        UseNmkrIpfs
-                            { label = "Own NMKR IPFS"
-                            , description = "Using NMKR IPFS server to store your files. Remark that using NMKR own gateway will be faster to access pinned files: https://c-ipfs-gw.nmkr.io/ipfs/{file-hash-here}"
-                            , userId = userId
-                            , apiToken = form.nmkrApiToken
-                            }
-
-        CustomIPFS ->
-            let
-                -- Check that the IPFS server url looks legit
-                ipfsServerUrlSeemsLegit =
-                    case Url.fromString form.ipfsServer of
-                        Just _ ->
-                            Ok ()
-
-                        Nothing ->
-                            Err ("This url seems incorrect, it must look like this: https://subdomain.domain.org, instead I got this: " ++ form.ipfsServer)
-
-                -- Check that headers look valid
-                nonEmptyHeadersResult headers =
-                    if List.any (\( f, _ ) -> String.isEmpty f) headers then
-                        Err "Empty header fields are forbidden."
-
-                    else
-                        Ok ()
-            in
-            ipfsServerUrlSeemsLegit
-                |> Result.andThen (\_ -> nonEmptyHeadersResult form.headers)
-                |> Result.map
-                    (\_ ->
-                        UseCustomIpfs
-                            { label = "Custom IPFS Server"
-                            , description = "Using a custom IPFS server configuration to store your files. The RPC should provide the /add?pin=true endpoint with answers equivalent to those described in the official kubo IPFS RPC docs: https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-add"
-                            , ipfsServer = form.ipfsServer
-                            , headers = form.headers
-                            }
-                    )
-
-        CustomHosting ->
+validateIpfsForm : { label : String, description : String } -> StorageConfigForm -> Result String StorageConfig
+validateIpfsForm ipfsPreconfig form =
+    case form.mode of
+        ModeCustomHosting ->
             Ok <|
-                UseCustomHosting
+                StorageCustomHosting
                     { label = "Custom Storage"
                     , description = "Prepare the rationale with this app, but store it on a custom solution (e.g. on GitHub via permanent links). It is your responsibility to make sure your storage solution is immutable and sustainable."
                     }
 
-        CustomPrepublished ->
+        ModePrepublished ->
             Ok <|
-                UseCustomPrepublished
+                StoragePrepublished
                     { label = "Custom Storage - Prepublished"
                     , description = "Your rationale is already published, we'll just link to it. It is your responsibility to ensure your storage solution is immutable and sustainable."
                     }
 
-        NoStorage ->
+        ModeNoStorage ->
             Ok <|
-                UseNoStorage
+                StorageNoRationale
                     { label = "No Rationale"
                     , description = "Are you REALLY sure you don’t want to add a rationale? This is NOT RECOMMENDED because proposers, reviewers, and delegators cannot understand the reasoning behind your decision."
                     }
+
+        ModePublish ->
+            if publishSetIsEmpty form.publishSet then
+                Err "Please select at least one IPFS provider, or pick another mode."
+
+            else
+                buildPublishProviders ipfsPreconfig form
+                    |> Result.map StoragePublish
+
+
+buildPublishProviders : { label : String, description : String } -> StorageConfigForm -> Result String (List PublishProvider)
+buildPublishProviders ipfsPreconfig form =
+    let
+        s =
+            form.publishSet
+
+        addPreconfig acc =
+            if s.preconfig then
+                Ok (PreconfigIpfs ipfsPreconfig :: acc)
+
+            else
+                Ok acc
+
+        addBlockfrost acc =
+            if s.blockfrost then
+                case String.trim form.blockfrostProjectId of
+                    "" ->
+                        Err "Missing blockfrost project id"
+
+                    projectId ->
+                        Ok
+                            (BlockfrostIpfs
+                                { label = "Own Blockfrost IPFS"
+                                , description = "Using Blockfrost IPFS server to store your files."
+                                , projectId = projectId
+                                }
+                                :: acc
+                            )
+
+            else
+                Ok acc
+
+        addNmkr acc =
+            if s.nmkr then
+                case String.trim form.nmkrUserId of
+                    "" ->
+                        Err "Missing nmkr user id"
+
+                    userId ->
+                        Ok
+                            (NmkrIpfs
+                                { label = "Own NMKR IPFS"
+                                , description = "Using NMKR IPFS server to store your files. Remark that using NMKR own gateway will be faster to access pinned files: https://c-ipfs-gw.nmkr.io/ipfs/{file-hash-here}"
+                                , userId = userId
+                                , apiToken = form.nmkrApiToken
+                                }
+                                :: acc
+                            )
+
+            else
+                Ok acc
+
+        addCustomIpfs acc =
+            if s.customIpfs then
+                let
+                    ipfsServerUrlSeemsLegit =
+                        case Url.fromString form.ipfsServer of
+                            Just _ ->
+                                Ok ()
+
+                            Nothing ->
+                                Err ("This url seems incorrect, it must look like this: https://subdomain.domain.org, instead I got this: " ++ form.ipfsServer)
+
+                    nonEmptyHeadersResult =
+                        if List.any (\( f, _ ) -> String.isEmpty f) form.headers then
+                            Err "Empty header fields are forbidden."
+
+                        else
+                            Ok ()
+                in
+                ipfsServerUrlSeemsLegit
+                    |> Result.andThen (\_ -> nonEmptyHeadersResult)
+                    |> Result.map
+                        (\_ ->
+                            CustomIpfsProvider
+                                { label = "Custom IPFS Server"
+                                , description = "Using a custom IPFS server configuration to store your files. The RPC should provide the /add?pin=true endpoint with answers equivalent to those described in the official kubo IPFS RPC docs: https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-add"
+                                , ipfsServer = form.ipfsServer
+                                , headers = form.headers
+                                }
+                                :: acc
+                        )
+
+            else
+                Ok acc
+    in
+    addPreconfig []
+        |> Result.andThen addBlockfrost
+        |> Result.andThen addNmkr
+        |> Result.andThen addCustomIpfs
+        |> Result.map List.reverse
 
 
 
@@ -2419,7 +2636,7 @@ isH1Block block =
             False
 
 
-validateRationaleForm : Bool -> Step RationaleForm Rationale Rationale -> Step RationaleForm Rationale Rationale
+validateRationaleForm : Bool -> Step RationaleForm RationaleValidating Rationale -> Step RationaleForm RationaleValidating Rationale
 validateRationaleForm hostingIsAppControlled step =
     case step of
         Preparing form ->
@@ -2450,9 +2667,12 @@ validateRationaleForm hostingIsAppControlled step =
                 ( Ok _, True ) ->
                     let
                         formWithoutError =
-                            { form | error = Nothing }
+                            { form | error = Nothing, pdfPartialFailures = [] }
                     in
-                    Validating formWithoutError (rationaleFromForm formWithoutError)
+                    Validating formWithoutError
+                        { rationale = rationaleFromForm formWithoutError
+                        , uploads = emptyUploadProgress
+                        }
 
                 ( Err err, _ ) ->
                     Preparing { form | error = Just err }
@@ -2602,54 +2822,62 @@ pinPdfFile fileAsValue (Model model) =
             , Cmd.none
             )
 
-        ( Ok file, Done _ storageConfig, Validating _ _ ) ->
-            ( Model model
-            , case storageConfig of
-                UsePreconfigIpfs _ ->
-                    Api.defaultApiProvider.ipfsAddFile
-                        { file = file }
-                        GotIpfsAnswer
+        ( Ok file, Done _ storageConfig, Validating form validating ) ->
+            let
+                providers =
+                    storedProviders storageConfig
 
-                UseBlockfrostIpfs { projectId } ->
-                    Api.defaultApiProvider.ipfsAddFileBlockfrost
-                        { projectId = projectId
-                        , file = file
-                        }
-                        GotIpfsAnswer
+                kinds =
+                    List.map providerKind providers
+            in
+            if List.isEmpty providers then
+                ( Model
+                    { model
+                        | rationaleCreationStep =
+                            Preparing { form | error = Just "No IPFS provider selected to upload the PDF to." }
+                    }
+                , Cmd.none
+                )
 
-                UseNmkrIpfs { userId, apiToken } ->
-                    Api.defaultApiProvider.ipfsAddFileNmkr
-                        { userId = userId
-                        , apiToken = apiToken
-                        , file = file
-                        }
-                        GotIpfsAnswer
-
-                UseCustomIpfs { ipfsServer, headers } ->
-                    Api.defaultApiProvider.ipfsAddFileCustom
-                        { rpc = ipfsServer
-                        , headers = headers
-                        , file = file
-                        }
-                        GotIpfsAnswer
-
-                -- There isn’t supposed to be any PDF to pin for the rest
-                UseCustomHosting _ ->
-                    Cmd.none
-
-                UseCustomPrepublished _ ->
-                    Cmd.none
-
-                UseNoStorage _ ->
-                    Cmd.none
-            )
+            else
+                ( Model
+                    { model
+                        | rationaleCreationStep =
+                            Validating form { validating | uploads = initUploadProgress kinds }
+                    }
+                , Cmd.batch (List.map (uploadFileCmd file) providers)
+                )
 
         -- Ignore if we aren't validating the rationale storage step
         _ ->
             ( Model model, Cmd.none )
 
 
-editRationale : Step RationaleForm Rationale Rationale -> Step RationaleForm Rationale Rationale
+uploadFileCmd : File -> PublishProvider -> Cmd Msg
+uploadFileCmd file provider =
+    case provider of
+        PreconfigIpfs _ ->
+            Api.defaultApiProvider.ipfsAddFile
+                { file = file }
+                (GotIpfsAnswer PreconfigKind)
+
+        BlockfrostIpfs { projectId } ->
+            Api.defaultApiProvider.ipfsAddFileBlockfrost
+                { projectId = projectId, file = file }
+                (GotIpfsAnswer BlockfrostKind)
+
+        NmkrIpfs { userId, apiToken } ->
+            Api.defaultApiProvider.ipfsAddFileNmkr
+                { userId = userId, apiToken = apiToken, file = file }
+                (GotIpfsAnswer NmkrKind)
+
+        CustomIpfsProvider { ipfsServer, headers } ->
+            Api.defaultApiProvider.ipfsAddFileCustom
+                { rpc = ipfsServer, headers = headers, file = file }
+                (GotIpfsAnswer CustomIpfsKind)
+
+
+editRationale : Step RationaleForm RationaleValidating Rationale -> Step RationaleForm RationaleValidating Rationale
 editRationale step =
     case step of
         Preparing _ ->
@@ -3009,7 +3237,7 @@ sendPinRequest ctx form model =
                 fileName =
                     "rationale-" ++ govActionId ++ ".json"
             in
-            ( { model | permanentStorageStep = Validating { form | error = Nothing } {} }
+            ( { model | permanentStorageStep = Validating { form | error = Nothing } emptyUploadProgress }
             , ctx.jsonRationaleToFile
                 { fileContent = ratSig.signedJson
                 , fileName = fileName
@@ -3032,152 +3260,186 @@ pinRationaleFile fileAsValue (Model model) =
             , Cmd.none
             )
 
-        ( Ok file, Done _ storageConfig, Validating _ _ ) ->
-            ( Model model
-            , case storageConfig of
-                UsePreconfigIpfs _ ->
-                    Api.defaultApiProvider.ipfsAddFile
-                        { file = file }
-                        GotIpfsAnswer
+        ( Ok file, Done _ storageConfig, Validating form _ ) ->
+            let
+                providers =
+                    storedProviders storageConfig
 
-                UseBlockfrostIpfs { projectId } ->
-                    Api.defaultApiProvider.ipfsAddFileBlockfrost
-                        { projectId = projectId
-                        , file = file
-                        }
-                        GotIpfsAnswer
+                kinds =
+                    List.map providerKind providers
+            in
+            if List.isEmpty providers then
+                ( Model
+                    { model
+                        | permanentStorageStep =
+                            Preparing { form | error = Just "No IPFS provider selected to upload the rationale to." }
+                    }
+                , Cmd.none
+                )
 
-                UseNmkrIpfs { userId, apiToken } ->
-                    Api.defaultApiProvider.ipfsAddFileNmkr
-                        { userId = userId
-                        , apiToken = apiToken
-                        , file = file
-                        }
-                        GotIpfsAnswer
-
-                UseCustomIpfs { ipfsServer, headers } ->
-                    Api.defaultApiProvider.ipfsAddFileCustom
-                        { rpc = ipfsServer
-                        , headers = headers
-                        , file = file
-                        }
-                        GotIpfsAnswer
-
-                -- There is nothing to pin for the rest
-                UseCustomHosting _ ->
-                    Cmd.none
-
-                UseCustomPrepublished _ ->
-                    Cmd.none
-
-                UseNoStorage _ ->
-                    Cmd.none
-            )
+            else
+                ( Model
+                    { model
+                        | permanentStorageStep =
+                            Validating form (initUploadProgress kinds)
+                    }
+                , Cmd.batch (List.map (uploadFileCmd file) providers)
+                )
 
         -- Ignore if we aren't validating the rationale storage step
         _ ->
             ( Model model, Cmd.none )
 
 
-handlePdfIpfsAnswer : UpdateContext msg -> InnerModel -> RationaleForm -> Rationale -> IpfsAnswer -> ( InnerModel, Cmd msg, Maybe MsgToParent )
-handlePdfIpfsAnswer ctx model form rationale ipfsAnswer =
-    case ( model.pickProposalStep, ipfsAnswer ) of
-        ( _, IpfsError error ) ->
-            ( { model | rationaleCreationStep = Preparing { form | error = Just error } }
-            , Cmd.none
-            , Nothing
-            )
+handlePdfIpfsAnswer : UpdateContext msg -> InnerModel -> RationaleForm -> RationaleValidating -> ProviderKind -> Result String IpfsAnswer -> ( InnerModel, Cmd msg, Maybe MsgToParent )
+handlePdfIpfsAnswer ctx model form validating kind result =
+    let
+        newProgress =
+            recordUploadResult kind result validating.uploads
 
-        -- Edit the rationale to prepend a link to the PDF at the beginning of the rationale statement,
-        -- and in the list of references.
-        ( Done _ { id }, IpfsAddSuccessful file ) ->
-            let
-                ipfsUri =
-                    "ipfs://" ++ file.cid
+        rationale =
+            validating.rationale
+    in
+    if not (uploadProgressIsDone newProgress) then
+        ( { model | rationaleCreationStep = Validating form { validating | uploads = newProgress } }
+        , Cmd.none
+        , Nothing
+        )
 
-                pdfLink =
-                    Helper.ipfsToHttpsUrl ipfsUri
+    else
+        case ( model.pickProposalStep, List.reverse newProgress.succeeded, List.reverse newProgress.failed ) of
+            -- All providers failed: surface the combined error and go back to editing
+            ( _, [], failures ) ->
+                ( { model
+                    | rationaleCreationStep =
+                        Preparing
+                            { form
+                                | error =
+                                    Just <|
+                                        "PDF upload failed on all selected providers:\n"
+                                            ++ formatUploadFailures failures
+                            }
+                  }
+                , Cmd.none
+                , Nothing
+                )
 
-                updatedRationaleStatement =
-                    "A [PDF version][pdf-link] of this rationale is also made available."
-                        ++ "\n\n"
-                        ++ ("[pdf-link]: " ++ pdfLink)
-                        ++ "\n\n"
-                        ++ rationale.rationaleStatement
+            -- At least one provider succeeded: use the first success as the PDF link
+            ( Done _ { id }, ( _, file ) :: _, failures ) ->
+                let
+                    ipfsUri =
+                        "ipfs://" ++ file.cid
 
-                updatedReferences =
-                    rationale.references
-                        ++ [ { type_ = OtherRefType
-                             , label = "Rationale PDF"
-                             , uri = ipfsUri
-                             }
-                           ]
+                    pdfLink =
+                        Helper.ipfsToHttpsUrl ipfsUri
 
-                updatedRationale =
-                    { rationale
-                        | rationaleStatement = updatedRationaleStatement
-                        , references = updatedReferences
-                    }
+                    updatedRationaleStatement =
+                        "A [PDF version][pdf-link] of this rationale is also made available."
+                            ++ "\n\n"
+                            ++ ("[pdf-link]: " ++ pdfLink)
+                            ++ "\n\n"
+                            ++ rationale.rationaleStatement
 
-                -- Initialize rationale signature form with authors (empty unless preconfigured)
-                rationaleSignatureForm =
-                    { authors = List.map (.name >> ProposalMetadata.justAuthorName) ctx.authorPreconfig
-                    , rationale = updatedRationale
-                    , error = Nothing
-                    }
-            in
-            ( { model
-                | rationaleCreationStep = Done { form | error = Nothing } updatedRationale
-                , rationaleSignatureStep =
-                    Done rationaleSignatureForm (rationaleSignatureFromForm ctx.jsonLdContexts id rationaleSignatureForm)
-              }
-            , Cmd.none
-            , Nothing
-            )
+                    updatedReferences =
+                        rationale.references
+                            ++ [ { type_ = OtherRefType
+                                 , label = "Rationale PDF"
+                                 , uri = ipfsUri
+                                 }
+                               ]
 
-        -- Do nothing if no proposal was picked yet
-        ( _, IpfsAddSuccessful _ ) ->
-            ( model, Cmd.none, Nothing )
+                    updatedRationale =
+                        { rationale
+                            | rationaleStatement = updatedRationaleStatement
+                            , references = updatedReferences
+                        }
+
+                    rationaleSignatureForm =
+                        { authors = List.map (.name >> ProposalMetadata.justAuthorName) ctx.authorPreconfig
+                        , rationale = updatedRationale
+                        , error = Nothing
+                        }
+                in
+                ( { model
+                    | rationaleCreationStep =
+                        Done { form | error = Nothing, pdfPartialFailures = failures } updatedRationale
+                    , rationaleSignatureStep =
+                        Done rationaleSignatureForm (rationaleSignatureFromForm ctx.jsonLdContexts id rationaleSignatureForm)
+                  }
+                , Cmd.none
+                , Nothing
+                )
+
+            -- No proposal picked yet (shouldn't happen at this point) — keep state.
+            _ ->
+                ( model, Cmd.none, Nothing )
 
 
-handleRationaleIpfsAnswer : InnerModel -> StorageForm -> IpfsAnswer -> ( InnerModel, Cmd msg, Maybe MsgToParent )
-handleRationaleIpfsAnswer model form ipfsAnswer =
-    case ( ipfsAnswer, model.rationaleSignatureStep, model.pickProposalStep ) of
-        ( IpfsError error, _, _ ) ->
-            ( { model | permanentStorageStep = Preparing { form | error = Just error } }
-            , Cmd.none
-            , Nothing
-            )
+handleRationaleIpfsAnswer : InnerModel -> StorageForm -> UploadProgress -> ProviderKind -> Result String IpfsAnswer -> ( InnerModel, Cmd msg, Maybe MsgToParent )
+handleRationaleIpfsAnswer model form progress kind result =
+    let
+        newProgress =
+            recordUploadResult kind result progress
+    in
+    if not (uploadProgressIsDone newProgress) then
+        ( { model | permanentStorageStep = Validating form newProgress }
+        , Cmd.none
+        , Nothing
+        )
 
-        ( IpfsAddSuccessful file, Done _ r, Done _ { id } ) ->
-            let
-                rawJson =
-                    r.signedJson
+    else
+        case ( model.rationaleSignatureStep, model.pickProposalStep, List.reverse newProgress.succeeded ) of
+            -- All failed: go back to the form with combined error message.
+            ( _, _, [] ) ->
+                ( { model
+                    | permanentStorageStep =
+                        Preparing
+                            { form
+                                | error =
+                                    Just <|
+                                        "Rationale upload failed on all selected providers:\n"
+                                            ++ formatUploadFailures (List.reverse newProgress.failed)
+                            }
+                  }
+                , Cmd.none
+                , Nothing
+                )
 
-                fileName =
-                    "rationale-" ++ Gov.idToBech32 (GovActionId id) ++ ".json"
+            ( Done _ r, Done _ { id }, ( _, file ) :: _ ) ->
+                let
+                    rawJson =
+                        r.signedJson
 
-                uploadedFile =
-                    { name = file.name
-                    , size = file.size
-                    , identifier = IpfsIdentifier file.cid
-                    , raw = rawJson
-                    , dataHash =
-                        Blake2b256.fromString rawJson
-                            |> Blake2b256.toHex
-                            |> Bytes.fromHexUnchecked
-                    }
+                    fileName =
+                        "rationale-" ++ Gov.idToBech32 (GovActionId id) ++ ".json"
 
-                downloadCmd =
-                    File.Download.string fileName "application/json" rawJson
-            in
-            ( { model | permanentStorageStep = Done { form | error = Nothing } { jsonFile = uploadedFile } }
-            , downloadCmd
-            , Nothing
-            )
+                    uploadedFile =
+                        { name = file.name
+                        , size = file.size
+                        , identifier = IpfsIdentifier file.cid
+                        , raw = rawJson
+                        , dataHash =
+                            Blake2b256.fromString rawJson
+                                |> Blake2b256.toHex
+                                |> Bytes.fromHexUnchecked
+                        }
 
-        _ ->
-            ( model, Cmd.none, Nothing )
+                    downloadCmd =
+                        File.Download.string fileName "application/json" rawJson
+                in
+                ( { model
+                    | permanentStorageStep =
+                        Done { form | error = Nothing }
+                            { jsonFile = uploadedFile
+                            , partialFailures = List.reverse newProgress.failed
+                            }
+                  }
+                , downloadCmd
+                , Nothing
+                )
+
+            _ ->
+                ( model, Cmd.none, Nothing )
 
 
 
@@ -3217,7 +3479,7 @@ allPrepSteps m =
             in
             case ( m.storageConfigStep, m.permanentStorageStep ) of
                 -- When there is no rationale:
-                ( Done _ (UseNoStorage _), _ ) ->
+                ( Done _ (StorageNoRationale _), _ ) ->
                     Ok
                         { voter = voter
                         , actionId = p.id
@@ -4349,39 +4611,20 @@ viewStorageConfigStep ctx step =
                     , Html.p [ HA.class "mb-4" ]
                         [ text "Only a link to your rationale is stored on Cardano,"
                         , text " so it's recommended to store the actual file containing the text in a permanent storage solution."
-                        , text " Here we provide multiple options."
+                        , text " Pick one of the modes below."
                         ]
-                    , Helper.storageConfigCard "Select Rationale Storage"
+                    , Helper.storageConfigCard "Storage Mode"
                         [ Helper.viewGrid 240
-                            [ Helper.storageMethodOption ctx.ipfsPreconfig.label (form.storageMethod == PreconfigIPFS ctx.ipfsPreconfig) (StorageMethodSelected <| PreconfigIPFS ctx.ipfsPreconfig)
-                            , Helper.storageMethodOption "Own Blockfrost IPFS" (form.storageMethod == BlockfrostIPFS) (StorageMethodSelected BlockfrostIPFS)
-                            , Helper.storageMethodOption "Own NMKR IPFS" (form.storageMethod == NmkrIPFS) (StorageMethodSelected NmkrIPFS)
-                            , Helper.storageMethodOption "Custom IPFS server" (form.storageMethod == CustomIPFS) (StorageMethodSelected CustomIPFS)
-                            , Helper.storageMethodOption "Custom Storage" (form.storageMethod == CustomHosting) (StorageMethodSelected CustomHosting)
-                            , Helper.storageMethodOption "Custom Storage - Prepublished" (form.storageMethod == CustomPrepublished) (StorageMethodSelected CustomPrepublished)
-                            , Helper.storageMethodOption "No Rationale" (form.storageMethod == NoStorage) (StorageMethodSelected NoStorage)
+                            [ Helper.storageMethodOption "Publish to IPFS" (form.mode == ModePublish) (StorageModeSelected ModePublish)
+                            , Helper.storageMethodOption "No Rationale" (form.mode == ModeNoStorage) (StorageModeSelected ModeNoStorage)
+                            , Helper.storageMethodOption "Custom Storage" (form.mode == ModeCustomHosting) (StorageModeSelected ModeCustomHosting)
+                            , Helper.storageMethodOption "Custom Storage - Prepublished" (form.mode == ModePrepublished) (StorageModeSelected ModePrepublished)
                             ]
-                        , case form.storageMethod of
-                            BlockfrostIPFS ->
-                                viewBlockfrostForm form
+                        , if form.mode == ModePublish then
+                            viewPublishProviderSelection ctx form
 
-                            NmkrIPFS ->
-                                viewNmkrForm form
-
-                            CustomIPFS ->
-                                viewCustomIpfsForm form
-
-                            PreconfigIPFS _ ->
-                                text ""
-
-                            CustomHosting ->
-                                text ""
-
-                            CustomPrepublished ->
-                                text ""
-
-                            NoStorage ->
-                                text ""
+                          else
+                            text ""
                         ]
                     , Html.p [ HA.class "mt-6" ] [ Helper.viewButton "Validate storage config" ValidateStorageConfigButtonClicked ]
                     , viewError form.error
@@ -4401,6 +4644,39 @@ viewStorageConfigStep ctx step =
                 , Html.p [ HA.style "margin-top" "1rem" ]
                     [ Html.map ctx.wrapMsg <| Helper.viewButton "Change storage configuration" ValidateStorageConfigButtonClicked ]
                 ]
+
+
+viewPublishProviderSelection : ViewContext msg -> StorageConfigForm -> Html Msg
+viewPublishProviderSelection ctx form =
+    let
+        s =
+            form.publishSet
+    in
+    div []
+        [ Html.p [ HA.class "mt-4 mb-2" ]
+            [ text "Pick one or more IPFS providers to publish to. The rationale will be uploaded to every selected provider; the upload succeeds if at least one provider succeeds." ]
+        , Helper.viewGrid 240
+            [ Helper.storageMethodOption ctx.ipfsPreconfig.label s.preconfig (PublishProviderToggled PreconfigKind (not s.preconfig))
+            , Helper.storageMethodOption "Own Blockfrost IPFS" s.blockfrost (PublishProviderToggled BlockfrostKind (not s.blockfrost))
+            , Helper.storageMethodOption "Own NMKR IPFS" s.nmkr (PublishProviderToggled NmkrKind (not s.nmkr))
+            , Helper.storageMethodOption "Custom IPFS server" s.customIpfs (PublishProviderToggled CustomIpfsKind (not s.customIpfs))
+            ]
+        , if s.blockfrost then
+            viewBlockfrostForm form
+
+          else
+            text ""
+        , if s.nmkr then
+            viewNmkrForm form
+
+          else
+            text ""
+        , if s.customIpfs then
+            viewCustomIpfsForm form
+
+          else
+            text ""
+        ]
 
 
 viewBlockfrostForm : StorageConfigForm -> Html Msg
@@ -4487,26 +4763,48 @@ viewCustomIpfsForm form =
 
 viewStorageConfigInfo : StorageConfig -> Html msg
 viewStorageConfigInfo config =
-    let
-        defaultStorageConfigInfo label description =
-            Helper.storageProviderCard
-                [ Html.h4
-                    [ HA.style "font-weight" "600"
-                    , HA.style "margin-bottom" "0.5rem"
-                    ]
-                    [ text label ]
-                , Html.p
-                    [ HA.style "color" "#4A5568"
-                    , HA.style "font-size" "0.875rem"
-                    ]
-                    [ text description ]
-                ]
-    in
     case config of
-        UsePreconfigIpfs { label, description } ->
+        StoragePublish providers ->
+            div
+                [ HA.style "display" "flex"
+                , HA.style "flex-direction" "column"
+                , HA.style "gap" "1rem"
+                ]
+                (List.map viewPublishProviderInfo providers)
+
+        StorageCustomHosting { label, description } ->
             defaultStorageConfigInfo label description
 
-        UseBlockfrostIpfs { label, description, projectId } ->
+        StoragePrepublished { label, description } ->
+            defaultStorageConfigInfo label description
+
+        StorageNoRationale { label, description } ->
+            defaultStorageConfigInfo label description
+
+
+defaultStorageConfigInfo : String -> String -> Html msg
+defaultStorageConfigInfo label description =
+    Helper.storageProviderCard
+        [ Html.h4
+            [ HA.style "font-weight" "600"
+            , HA.style "margin-bottom" "0.5rem"
+            ]
+            [ text label ]
+        , Html.p
+            [ HA.style "color" "#4A5568"
+            , HA.style "font-size" "0.875rem"
+            ]
+            [ text description ]
+        ]
+
+
+viewPublishProviderInfo : PublishProvider -> Html msg
+viewPublishProviderInfo provider =
+    case provider of
+        PreconfigIpfs { label, description } ->
+            defaultStorageConfigInfo label description
+
+        BlockfrostIpfs { label, description, projectId } ->
             Helper.storageProviderCard
                 [ Html.h4
                     [ HA.style "font-weight" "600"
@@ -4527,10 +4825,35 @@ viewStorageConfigInfo config =
                     )
                 ]
 
-        UseNmkrIpfs { label, description } ->
-            defaultStorageConfigInfo label description
+        NmkrIpfs { label, description, userId, apiToken } ->
+            Helper.storageProviderCard
+                [ Html.h4
+                    [ HA.style "font-weight" "600"
+                    , HA.style "margin-bottom" "0.5rem"
+                    ]
+                    [ text label ]
+                , Html.p
+                    [ HA.style "color" "#4A5568"
+                    , HA.style "font-size" "0.875rem"
+                    ]
+                    [ text description ]
+                , Helper.storageConfigItem "User ID"
+                    (Html.p
+                        [ HA.style "font-family" "monospace"
+                        , HA.style "word-break" "break-all"
+                        ]
+                        [ text userId ]
+                    )
+                , Helper.storageConfigItem "API Token"
+                    (Html.p
+                        [ HA.style "font-family" "monospace"
+                        , HA.style "word-break" "break-all"
+                        ]
+                        [ text (maskToken apiToken) ]
+                    )
+                ]
 
-        UseCustomIpfs { label, description, ipfsServer } ->
+        CustomIpfsProvider { label, description, ipfsServer } ->
             Helper.storageProviderCard
                 [ Html.h4
                     [ HA.style "font-weight" "600"
@@ -4554,14 +4877,14 @@ viewStorageConfigInfo config =
                     )
                 ]
 
-        UseCustomHosting { label, description } ->
-            defaultStorageConfigInfo label description
 
-        UseCustomPrepublished { label, description } ->
-            defaultStorageConfigInfo label description
+maskToken : String -> String
+maskToken token =
+    if String.length token <= 12 then
+        String.repeat (String.length token) "•"
 
-        UseNoStorage { label, description } ->
-            defaultStorageConfigInfo label description
+    else
+        String.left 4 token ++ "…" ++ String.right 4 token
 
 
 
@@ -4574,18 +4897,18 @@ viewRationaleStep :
     ViewContext msg
     -> Step {} {} ActiveProposal
     -> Step StorageConfigForm {} StorageConfig
-    -> Step RationaleForm Rationale Rationale
+    -> Step RationaleForm RationaleValidating Rationale
     -> Html msg
 viewRationaleStep ctx pickProposalStep storageConfigStep step =
     Html.map ctx.wrapMsg <|
         case ( pickProposalStep, storageConfigStep, step ) of
-            ( Done _ _, Done _ (UseCustomPrepublished { description }), _ ) ->
+            ( Done _ _, Done _ (StoragePrepublished { description }), _ ) ->
                 div []
                     [ Helper.sectionTitle "Vote Rationale"
                     , Helper.stepNotAvailableCard [ text description ]
                     ]
 
-            ( Done _ _, Done _ (UseNoStorage { description }), _ ) ->
+            ( Done _ _, Done _ (StorageNoRationale { description }), _ ) ->
                 div []
                     [ Helper.sectionTitle "Vote Rationale"
                     , Helper.stepNotAvailableCard [ text description ]
@@ -4603,8 +4926,8 @@ viewRationaleStep ctx pickProposalStep storageConfigStep step =
                         ]
                     ]
 
-            ( Done _ _, Done _ _, Done _ rationale ) ->
-                viewCompletedRationale rationale
+            ( Done _ _, Done _ _, Done form rationale ) ->
+                viewCompletedRationale form.pdfPartialFailures rationale
 
             ( _, Done _ _, _ ) ->
                 div []
@@ -4628,16 +4951,7 @@ viewRationaleStep ctx pickProposalStep storageConfigStep step =
 isHostingAppControlled : StorageConfig -> Bool
 isHostingAppControlled storageConfig =
     case storageConfig of
-        UsePreconfigIpfs _ ->
-            True
-
-        UseBlockfrostIpfs _ ->
-            True
-
-        UseNmkrIpfs _ ->
-            True
-
-        UseCustomIpfs _ ->
+        StoragePublish _ ->
             True
 
         _ ->
@@ -4753,8 +5067,8 @@ viewOneRefForm n reference =
         (ReferenceUriChange n)
 
 
-viewCompletedRationale : Rationale -> Html Msg
-viewCompletedRationale rationale =
+viewCompletedRationale : List ( ProviderKind, String ) -> Rationale -> Html Msg
+viewCompletedRationale pdfPartialFailures rationale =
     let
         statementSection =
             div [ HA.style "border-top" "1px solid #EDF2F7", HA.style "padding-top" "1.5rem" ]
@@ -4824,6 +5138,10 @@ viewCompletedRationale rationale =
         , internalVoteSection
         , referencesSection
         ]
+        [ Helper.viewPartialFailuresWithIntro
+            "PDF was uploaded successfully on at least one provider, but failed on:"
+            (labelProviderFailures pdfPartialFailures)
+        ]
         EditRationaleButtonClicked
 
 
@@ -4837,17 +5155,17 @@ viewRationaleSignatureStep :
     ViewContext msg
     -> Step {} {} ActiveProposal
     -> Step StorageConfigForm {} StorageConfig
-    -> Step RationaleForm Rationale Rationale
+    -> Step RationaleForm RationaleValidating Rationale
     -> Step RationaleSignatureForm {} RationaleSignature
     -> Html msg
 viewRationaleSignatureStep ctx pickProposalStep storageConfigStep rationaleCreationStep step =
     div []
         [ Helper.sectionTitle "Rationale Signature" -- Always show the title
         , case storageConfigStep of
-            Done _ (UseCustomPrepublished _) ->
+            Done _ (StoragePrepublished _) ->
                 Helper.stepNotAvailableCard [ text "Rationale is already published." ]
 
-            Done _ (UseNoStorage _) ->
+            Done _ (StorageNoRationale _) ->
                 Helper.stepNotAvailableCard [ text "No rationale." ]
 
             _ ->
@@ -5083,21 +5401,21 @@ viewPermanentStorageStep :
     -> Step {} {} ActiveProposal
     -> Step RationaleSignatureForm {} RationaleSignature
     -> Step StorageConfigForm {} StorageConfig
-    -> Step StorageForm {} Storage
+    -> Step StorageForm UploadProgress Storage
     -> Html msg
 viewPermanentStorageStep ctx pickProposalStep rationaleSignatureStep storageConfigStep step =
     Html.map ctx.wrapMsg <|
         div []
             [ Helper.sectionTitle "Rationale Storage"
             , case ( storageConfigStep, rationaleSignatureStep, step ) of
-                ( Done _ (UseNoStorage _), _, _ ) ->
+                ( Done _ (StorageNoRationale _), _, _ ) ->
                     Helper.cardContainer []
                         [ Helper.cardHeader [] "Step Not Available" "" []
                         , Helper.cardContent []
                             [ Html.p [] [ text "No rationale." ] ]
                         ]
 
-                ( Done _ (UseCustomPrepublished _), _, Preparing form ) ->
+                ( Done _ (StoragePrepublished _), _, Preparing form ) ->
                     div []
                         [ Helper.cardContainer []
                             [ Helper.cardHeader [] "Verify Published Rationale" "" []
@@ -5114,7 +5432,7 @@ viewPermanentStorageStep ctx pickProposalStep rationaleSignatureStep storageConf
                             [ Helper.viewButton "Check Rationale URI" CheckRationaleUrlButtonClicked ]
                         ]
 
-                ( Done _ (UseCustomHosting _), Done _ _, Preparing form ) ->
+                ( Done _ (StorageCustomHosting _), Done _ _, Preparing form ) ->
                     div []
                         [ Helper.cardContainer []
                             [ Helper.cardHeader [] "Verify Published Rationale" "" []
@@ -5139,7 +5457,7 @@ viewPermanentStorageStep ctx pickProposalStep rationaleSignatureStep storageConf
                 ( Done _ _, _, Validating _ _ ) ->
                     Helper.uploadingSpinner "Checking rationale storage..."
 
-                ( Done _ (UseCustomPrepublished _), _, Done _ storage ) ->
+                ( Done _ (StoragePrepublished _), _, Done _ storage ) ->
                     case pickProposalStep of
                         Done _ { id } ->
                             viewCompletedStorage (Just id) storage
@@ -5161,7 +5479,7 @@ viewPermanentStorageStep ctx pickProposalStep rationaleSignatureStep storageConf
 
 
 viewCompletedStorage : Maybe ActionId -> Storage -> Html Msg
-viewCompletedStorage maybeActionId { jsonFile } =
+viewCompletedStorage maybeActionId { jsonFile, partialFailures } =
     let
         fileName =
             case maybeActionId of
@@ -5216,8 +5534,14 @@ viewCompletedStorage maybeActionId { jsonFile } =
             , Html.p [ HA.style "margin" "1rem 0rem" ] [ Helper.downloadJSONButton "Download JSON rationale" { filename = fileName, rawJson = jsonFile.raw } ]
             , Helper.storageInfoGrid infoItems
             ]
+        , Helper.viewPartialFailuresWithIntro "Some IPFS providers failed:" (labelProviderFailures partialFailures)
         , Helper.viewButton "Change storage location" AddOtherStorageButtonCLicked
         ]
+
+
+labelProviderFailures : List ( ProviderKind, String ) -> List ( String, String )
+labelProviderFailures failures =
+    List.map (\( kind, err ) -> ( providerKindLabel kind, err )) failures
 
 
 
@@ -5410,10 +5734,10 @@ viewMissingStepsMessage model =
     let
         isRationaleAppCreated =
             case model.storageConfigStep of
-                Done _ (UseCustomPrepublished _) ->
+                Done _ (StoragePrepublished _) ->
                     False
 
-                Done _ (UseNoStorage _) ->
+                Done _ (StorageNoRationale _) ->
                     False
 
                 _ ->
@@ -5421,7 +5745,7 @@ viewMissingStepsMessage model =
 
         hasRationale =
             case model.storageConfigStep of
-                Done _ (UseNoStorage _) ->
+                Done _ (StorageNoRationale _) ->
                     False
 
                 _ ->

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -4528,7 +4528,23 @@ viewIpfsProviderSelection ctx form =
                 _ ->
                     Nothing
     in
-    div [] (providerCards :: List.filterMap providerConfig form.publishSet)
+    div [] (providerCards :: (List.filterMap providerConfig <| List.sortBy ipfsProviderOrder form.publishSet))
+
+
+ipfsProviderOrder : ProviderKind -> Int
+ipfsProviderOrder kind =
+    case kind of
+        BlockfrostKind ->
+            0
+
+        NmkrKind ->
+            1
+
+        CustomIpfsKind ->
+            2
+
+        _ ->
+            -1
 
 
 viewBlockfrostForm : StorageConfigForm -> Html Msg

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -128,14 +128,14 @@ type Cip100VerificationState
     | VerificationError String
 
 
-init : { label : String, description : String } -> Model
-init ipfsPreconfig =
+init : Model
+init =
     Model
         { someRefUtxos = Utxo.emptyRefDict
         , reloadedLastVoter = False
         , voterStep = Preparing initVoterForm
         , pickProposalStep = Preparing {}
-        , storageConfigStep = Done initStorageConfigForm (StoragePublish [ PreconfigIpfs ipfsPreconfig ])
+        , storageConfigStep = Done initStorageConfigForm (StoragePublish [ PreconfigIpfs ])
         , rationaleCreationStep = Preparing initRationaleForm
         , rationaleSignatureStep = Preparing initRationaleSignatureForm
         , permanentStorageStep = Preparing initStorageForm
@@ -312,6 +312,57 @@ providerKindLabel ipfsPreconfig kind =
 
         CustomIpfsKind ->
             "Custom IPFS"
+
+
+providerKindDescription : IpfsPreconfig -> ProviderKind -> String
+providerKindDescription ipfsPreconfig kind =
+    case kind of
+        PreconfigKind ->
+            ipfsPreconfig.description
+
+        BlockfrostKind ->
+            "Using Blockfrost IPFS server to store your files."
+
+        NmkrKind ->
+            "Using NMKR IPFS server to store your files. Remark that using NMKR own gateway will be faster to access pinned files: https://c-ipfs-gw.nmkr.io/ipfs/{file-hash-here}"
+
+        CustomIpfsKind ->
+            "Using a custom IPFS server configuration to store your files. The RPC should provide the /add?pin=true endpoint with answers equivalent to those described in the official kubo IPFS RPC docs: https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-add"
+
+
+{-| User-facing label/description for the three non-publish storage modes.
+Returns `Nothing` for `StoragePublish`, whose info is derived per-provider.
+-}
+storageConfigInfo : StorageConfig -> Maybe { label : String, description : String }
+storageConfigInfo config =
+    case config of
+        StoragePublish _ ->
+            Nothing
+
+        StorageCustomHosting ->
+            Just
+                { label = "Custom Storage"
+                , description = "Prepare the rationale with this app, but store it on a custom solution (e.g. on GitHub via permanent links). It is your responsibility to make sure your storage solution is immutable and sustainable."
+                }
+
+        StoragePrepublished ->
+            Just
+                { label = "Custom Storage - Prepublished"
+                , description = "Your rationale is already published, we'll just link to it. It is your responsibility to ensure your storage solution is immutable and sustainable."
+                }
+
+        StorageNoRationale ->
+            Just
+                { label = "No Rationale"
+                , description = "Are you REALLY sure you don’t want to add a rationale? This is NOT RECOMMENDED because proposers, reviewers, and delegators cannot understand the reasoning behind your decision."
+                }
+
+
+storageConfigDescription : StorageConfig -> String
+storageConfigDescription config =
+    storageConfigInfo config
+        |> Maybe.map .description
+        |> Maybe.withDefault ""
 
 
 formatUploadFailures : IpfsPreconfig -> List ( ProviderKind, String ) -> String
@@ -514,20 +565,20 @@ formFromStorageConfig config =
                 { initStorageConfigForm | mode = ModePublish, publishSet = emptyPublishSet }
                 providers
 
-        StorageCustomHosting _ ->
+        StorageCustomHosting ->
             { initStorageConfigForm | mode = ModeCustomHosting, publishSet = emptyPublishSet }
 
-        StoragePrepublished _ ->
+        StoragePrepublished ->
             { initStorageConfigForm | mode = ModePrepublished, publishSet = emptyPublishSet }
 
-        StorageNoRationale _ ->
+        StorageNoRationale ->
             { initStorageConfigForm | mode = ModeNoStorage, publishSet = emptyPublishSet }
 
 
 applyProviderToForm : PublishProvider -> StorageConfigForm -> StorageConfigForm
 applyProviderToForm provider form =
     case provider of
-        PreconfigIpfs _ ->
+        PreconfigIpfs ->
             { form | publishSet = publishSetSet PreconfigKind True form.publishSet }
 
         BlockfrostIpfs { projectId } ->
@@ -552,18 +603,21 @@ applyProviderToForm provider form =
 
 
 {-| One of the IPFS providers the rationale can be published to.
+The user-facing label and description for each variant are not stored
+on the variant itself; they are derived at view time from `ProviderKind`
+(and, for `PreconfigIpfs`, from the app-init `IpfsPreconfig`).
 -}
 type PublishProvider
-    = PreconfigIpfs { label : String, description : String }
-    | BlockfrostIpfs { label : String, description : String, projectId : String }
-    | NmkrIpfs { label : String, description : String, userId : String, apiToken : String }
-    | CustomIpfsProvider { label : String, description : String, ipfsServer : String, headers : List ( String, String ) }
+    = PreconfigIpfs
+    | BlockfrostIpfs { projectId : String }
+    | NmkrIpfs { userId : String, apiToken : String }
+    | CustomIpfsProvider { ipfsServer : String, headers : List ( String, String ) }
 
 
 providerKind : PublishProvider -> ProviderKind
 providerKind provider =
     case provider of
-        PreconfigIpfs _ ->
+        PreconfigIpfs ->
             PreconfigKind
 
         BlockfrostIpfs _ ->
@@ -578,9 +632,9 @@ providerKind provider =
 
 type StorageConfig
     = StoragePublish (List PublishProvider)
-    | StorageCustomHosting { label : String, description : String }
-    | StoragePrepublished { label : String, description : String }
-    | StorageNoRationale { label : String, description : String }
+    | StorageCustomHosting
+    | StoragePrepublished
+    | StorageNoRationale
 
 
 storedProviders : StorageConfig -> List PublishProvider
@@ -595,9 +649,9 @@ storedProviders config =
 
 {-| Initialize the default storage config.
 -}
-initStorageConfig : { label : String, description : String } -> StorageConfig
-initStorageConfig { label, description } =
-    StoragePublish [ PreconfigIpfs { label = label, description = description } ]
+initStorageConfig : StorageConfig
+initStorageConfig =
+    StoragePublish [ PreconfigIpfs ]
 
 
 encodeStorageConfig : StorageConfig -> JE.Value
@@ -609,60 +663,38 @@ encodeStorageConfig config =
                 , ( "providers", JE.list encodePublishProvider providers )
                 ]
 
-        StorageCustomHosting { label, description } ->
-            JE.object
-                [ ( "kind", JE.string "StorageCustomHosting" )
-                , ( "label", JE.string label )
-                , ( "description", JE.string description )
-                ]
+        StorageCustomHosting ->
+            JE.object [ ( "kind", JE.string "StorageCustomHosting" ) ]
 
-        StoragePrepublished { label, description } ->
-            JE.object
-                [ ( "kind", JE.string "StoragePrepublished" )
-                , ( "label", JE.string label )
-                , ( "description", JE.string description )
-                ]
+        StoragePrepublished ->
+            JE.object [ ( "kind", JE.string "StoragePrepublished" ) ]
 
-        StorageNoRationale { label, description } ->
-            JE.object
-                [ ( "kind", JE.string "StorageNoRationale" )
-                , ( "label", JE.string label )
-                , ( "description", JE.string description )
-                ]
+        StorageNoRationale ->
+            JE.object [ ( "kind", JE.string "StorageNoRationale" ) ]
 
 
 encodePublishProvider : PublishProvider -> JE.Value
 encodePublishProvider provider =
     case provider of
-        PreconfigIpfs { label, description } ->
-            JE.object
-                [ ( "type", JE.string "PreconfigIpfs" )
-                , ( "label", JE.string label )
-                , ( "description", JE.string description )
-                ]
+        PreconfigIpfs ->
+            JE.object [ ( "type", JE.string "PreconfigIpfs" ) ]
 
-        BlockfrostIpfs { label, description, projectId } ->
+        BlockfrostIpfs { projectId } ->
             JE.object
                 [ ( "type", JE.string "BlockfrostIpfs" )
-                , ( "label", JE.string label )
-                , ( "description", JE.string description )
                 , ( "projectId", JE.string projectId )
                 ]
 
-        NmkrIpfs { label, description, userId, apiToken } ->
+        NmkrIpfs { userId, apiToken } ->
             JE.object
                 [ ( "type", JE.string "NmkrIpfs" )
-                , ( "label", JE.string label )
-                , ( "description", JE.string description )
                 , ( "userId", JE.string userId )
                 , ( "apiToken", JE.string apiToken )
                 ]
 
-        CustomIpfsProvider { label, description, ipfsServer, headers } ->
+        CustomIpfsProvider { ipfsServer, headers } ->
             JE.object
                 [ ( "type", JE.string "CustomIpfs" )
-                , ( "label", JE.string label )
-                , ( "description", JE.string description )
                 , ( "ipfsServer", JE.string ipfsServer )
                 , ( "headers", JE.list encodeHttpHeader headers )
                 ]
@@ -691,19 +723,13 @@ storageConfigDecoder =
                             |> JD.map StoragePublish
 
                     "StorageCustomHosting" ->
-                        JD.map2 (\label description -> StorageCustomHosting { label = label, description = description })
-                            (JD.field "label" JD.string)
-                            (JD.field "description" JD.string)
+                        JD.succeed StorageCustomHosting
 
                     "StoragePrepublished" ->
-                        JD.map2 (\label description -> StoragePrepublished { label = label, description = description })
-                            (JD.field "label" JD.string)
-                            (JD.field "description" JD.string)
+                        JD.succeed StoragePrepublished
 
                     "StorageNoRationale" ->
-                        JD.map2 (\label description -> StorageNoRationale { label = label, description = description })
-                            (JD.field "label" JD.string)
-                            (JD.field "description" JD.string)
+                        JD.succeed StorageNoRationale
 
                     _ ->
                         JD.fail ("Unknown storage kind: " ++ kind)
@@ -717,27 +743,19 @@ publishProviderDecoder =
             (\providerType ->
                 case providerType of
                     "PreconfigIpfs" ->
-                        JD.map2 (\label description -> PreconfigIpfs { label = label, description = description })
-                            (JD.field "label" JD.string)
-                            (JD.field "description" JD.string)
+                        JD.succeed PreconfigIpfs
 
                     "BlockfrostIpfs" ->
-                        JD.map3 (\label description projectId -> BlockfrostIpfs { label = label, description = description, projectId = projectId })
-                            (JD.field "label" JD.string)
-                            (JD.field "description" JD.string)
+                        JD.map (\projectId -> BlockfrostIpfs { projectId = projectId })
                             (JD.field "projectId" JD.string)
 
                     "NmkrIpfs" ->
-                        JD.map4 (\label description userId apiToken -> NmkrIpfs { label = label, description = description, userId = userId, apiToken = apiToken })
-                            (JD.field "label" JD.string)
-                            (JD.field "description" JD.string)
+                        JD.map2 (\userId apiToken -> NmkrIpfs { userId = userId, apiToken = apiToken })
                             (JD.field "userId" JD.string)
                             (JD.field "apiToken" JD.string)
 
                     "CustomIpfs" ->
-                        JD.map4 (\label description ipfsServer headers -> CustomIpfsProvider { label = label, description = description, ipfsServer = ipfsServer, headers = headers })
-                            (JD.field "label" JD.string)
-                            (JD.field "description" JD.string)
+                        JD.map2 (\ipfsServer headers -> CustomIpfsProvider { ipfsServer = ipfsServer, headers = headers })
                             (JD.field "ipfsServer" JD.string)
                             (JD.field "headers" (JD.list httpHeaderDecoder))
 
@@ -1202,7 +1220,7 @@ innerUpdate ctx msg model =
                                 -- Reset the rationale if it is not "pre-published"
                                 resetRationaleModel =
                                     case model.storageConfigStep of
-                                        Done _ (StoragePrepublished _) ->
+                                        Done _ StoragePrepublished ->
                                             model
 
                                         _ ->
@@ -1328,7 +1346,7 @@ innerUpdate ctx msg model =
         ValidateStorageConfigButtonClicked ->
             case model.storageConfigStep of
                 Preparing form ->
-                    case validateIpfsForm ctx.ipfsPreconfig form of
+                    case validateIpfsForm form of
                         Ok storageConfig ->
                             -- TODO: test some endpoint to check custom config validity,
                             -- and return a "Validating" step instead of a "Done" step.
@@ -1687,7 +1705,7 @@ innerUpdate ctx msg model =
                         let
                             raw =
                                 case ( storageConfig, model.rationaleSignatureStep ) of
-                                    ( StorageCustomHosting _, Done _ { signedJson } ) ->
+                                    ( StorageCustomHosting, Done _ { signedJson } ) ->
                                         Just signedJson
 
                                     _ ->
@@ -2472,48 +2490,36 @@ updateStorageConfigForm formUpdate model =
             model
 
 
-validateIpfsForm : { label : String, description : String } -> StorageConfigForm -> Result String StorageConfig
-validateIpfsForm ipfsPreconfig form =
+validateIpfsForm : StorageConfigForm -> Result String StorageConfig
+validateIpfsForm form =
     case form.mode of
         ModeCustomHosting ->
-            Ok <|
-                StorageCustomHosting
-                    { label = "Custom Storage"
-                    , description = "Prepare the rationale with this app, but store it on a custom solution (e.g. on GitHub via permanent links). It is your responsibility to make sure your storage solution is immutable and sustainable."
-                    }
+            Ok StorageCustomHosting
 
         ModePrepublished ->
-            Ok <|
-                StoragePrepublished
-                    { label = "Custom Storage - Prepublished"
-                    , description = "Your rationale is already published, we'll just link to it. It is your responsibility to ensure your storage solution is immutable and sustainable."
-                    }
+            Ok StoragePrepublished
 
         ModeNoStorage ->
-            Ok <|
-                StorageNoRationale
-                    { label = "No Rationale"
-                    , description = "Are you REALLY sure you don’t want to add a rationale? This is NOT RECOMMENDED because proposers, reviewers, and delegators cannot understand the reasoning behind your decision."
-                    }
+            Ok StorageNoRationale
 
         ModePublish ->
             if publishSetIsEmpty form.publishSet then
                 Err "Please select at least one IPFS provider, or pick another mode."
 
             else
-                buildPublishProviders ipfsPreconfig form
+                buildPublishProviders form
                     |> Result.map StoragePublish
 
 
-buildPublishProviders : { label : String, description : String } -> StorageConfigForm -> Result String (List PublishProvider)
-buildPublishProviders ipfsPreconfig form =
+buildPublishProviders : StorageConfigForm -> Result String (List PublishProvider)
+buildPublishProviders form =
     let
         s =
             form.publishSet
 
         addPreconfig acc =
             if s.preconfig then
-                Ok (PreconfigIpfs ipfsPreconfig :: acc)
+                Ok (PreconfigIpfs :: acc)
 
             else
                 Ok acc
@@ -2525,14 +2531,7 @@ buildPublishProviders ipfsPreconfig form =
                         Err "Missing blockfrost project id"
 
                     projectId ->
-                        Ok
-                            (BlockfrostIpfs
-                                { label = "Blockfrost"
-                                , description = "Using Blockfrost IPFS server to store your files."
-                                , projectId = projectId
-                                }
-                                :: acc
-                            )
+                        Ok (BlockfrostIpfs { projectId = projectId } :: acc)
 
             else
                 Ok acc
@@ -2544,15 +2543,7 @@ buildPublishProviders ipfsPreconfig form =
                         Err "Missing nmkr user id"
 
                     userId ->
-                        Ok
-                            (NmkrIpfs
-                                { label = "NMKR"
-                                , description = "Using NMKR IPFS server to store your files. Remark that using NMKR own gateway will be faster to access pinned files: https://c-ipfs-gw.nmkr.io/ipfs/{file-hash-here}"
-                                , userId = userId
-                                , apiToken = form.nmkrApiToken
-                                }
-                                :: acc
-                            )
+                        Ok (NmkrIpfs { userId = userId, apiToken = form.nmkrApiToken } :: acc)
 
             else
                 Ok acc
@@ -2580,9 +2571,7 @@ buildPublishProviders ipfsPreconfig form =
                     |> Result.map
                         (\_ ->
                             CustomIpfsProvider
-                                { label = "Custom IPFS"
-                                , description = "Using a custom IPFS server configuration to store your files. The RPC should provide the /add?pin=true endpoint with answers equivalent to those described in the official kubo IPFS RPC docs: https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-add"
-                                , ipfsServer = form.ipfsServer
+                                { ipfsServer = form.ipfsServer
                                 , headers = form.headers
                                 }
                                 :: acc
@@ -2863,7 +2852,7 @@ pinPdfFile fileAsValue (Model model) =
 uploadFileCmd : File -> PublishProvider -> Cmd Msg
 uploadFileCmd file provider =
     case provider of
-        PreconfigIpfs _ ->
+        PreconfigIpfs ->
             Api.defaultApiProvider.ipfsAddFile
                 { file = file }
                 (GotIpfsAnswer PreconfigKind)
@@ -3486,7 +3475,7 @@ allPrepSteps m =
             in
             case ( m.storageConfigStep, m.permanentStorageStep ) of
                 -- When there is no rationale:
-                ( Done _ (StorageNoRationale _), _ ) ->
+                ( Done _ StorageNoRationale, _ ) ->
                     Ok
                         { voter = voter
                         , actionId = p.id
@@ -4647,7 +4636,7 @@ viewStorageConfigStep ctx step =
             div []
                 [ Helper.sectionTitle "Vote Rationale Storage Config"
                 , Helper.storageConfigCard "Selected Storage Method"
-                    [ viewStorageConfigInfo storageConfig ]
+                    [ viewStorageConfigInfo ctx.ipfsPreconfig storageConfig ]
                 , Html.p [ HA.style "margin-top" "1rem" ]
                     [ Html.map ctx.wrapMsg <| Helper.viewButton "Change storage configuration" ValidateStorageConfigButtonClicked ]
                 ]
@@ -4660,7 +4649,7 @@ viewPublishProviderSelection ctx form =
             form.publishSet
     in
     div []
-        [ Helper.nestedSurface
+        [ Helper.nestedCard
             { heading = "IPFS providers"
             , sub = "Pick one or more. We upload to each; the step passes if any succeed."
             }
@@ -4771,8 +4760,8 @@ viewCustomIpfsForm form =
         ]
 
 
-viewStorageConfigInfo : StorageConfig -> Html msg
-viewStorageConfigInfo config =
+viewStorageConfigInfo : IpfsPreconfig -> StorageConfig -> Html msg
+viewStorageConfigInfo ipfsPreconfig config =
     case config of
         StoragePublish providers ->
             div
@@ -4780,16 +4769,15 @@ viewStorageConfigInfo config =
                 , HA.style "flex-direction" "column"
                 , HA.style "gap" "1rem"
                 ]
-                (List.map viewPublishProviderInfo providers)
+                (List.map (viewPublishProviderInfo ipfsPreconfig) providers)
 
-        StorageCustomHosting { label, description } ->
-            defaultStorageConfigInfo label description
+        _ ->
+            case storageConfigInfo config of
+                Just { label, description } ->
+                    defaultStorageConfigInfo label description
 
-        StoragePrepublished { label, description } ->
-            defaultStorageConfigInfo label description
-
-        StorageNoRationale { label, description } ->
-            defaultStorageConfigInfo label description
+                Nothing ->
+                    text ""
 
 
 defaultStorageConfigInfo : String -> String -> Html msg
@@ -4808,13 +4796,23 @@ defaultStorageConfigInfo label description =
         ]
 
 
-viewPublishProviderInfo : PublishProvider -> Html msg
-viewPublishProviderInfo provider =
+viewPublishProviderInfo : IpfsPreconfig -> PublishProvider -> Html msg
+viewPublishProviderInfo ipfsPreconfig provider =
+    let
+        kind =
+            providerKind provider
+
+        label =
+            providerKindLabel ipfsPreconfig kind
+
+        description =
+            providerKindDescription ipfsPreconfig kind
+    in
     case provider of
-        PreconfigIpfs { label, description } ->
+        PreconfigIpfs ->
             defaultStorageConfigInfo label description
 
-        BlockfrostIpfs { label, description, projectId } ->
+        BlockfrostIpfs { projectId } ->
             Helper.storageProviderCard
                 [ Helper.storageProviderHeader label description
                 , Helper.storageConfigItem "Project ID"
@@ -4826,7 +4824,7 @@ viewPublishProviderInfo provider =
                     )
                 ]
 
-        NmkrIpfs { label, description, userId, apiToken } ->
+        NmkrIpfs { userId, apiToken } ->
             Helper.storageProviderCard
                 [ Helper.storageProviderHeader label description
                 , Helper.storageConfigItem "User ID"
@@ -4845,7 +4843,7 @@ viewPublishProviderInfo provider =
                     )
                 ]
 
-        CustomIpfsProvider { label, description, ipfsServer } ->
+        CustomIpfsProvider { ipfsServer } ->
             Helper.storageProviderCard
                 [ Helper.storageProviderHeader label description
                 , Helper.storageConfigItem "IPFS Server"
@@ -4877,16 +4875,16 @@ viewRationaleStep :
 viewRationaleStep ctx pickProposalStep storageConfigStep step =
     Html.map ctx.wrapMsg <|
         case ( pickProposalStep, storageConfigStep, step ) of
-            ( Done _ _, Done _ (StoragePrepublished { description }), _ ) ->
+            ( Done _ _, Done _ StoragePrepublished, _ ) ->
                 div []
                     [ Helper.sectionTitle "Vote Rationale"
-                    , Helper.stepNotAvailableCard [ text description ]
+                    , Helper.stepNotAvailableCard [ text (storageConfigDescription StoragePrepublished) ]
                     ]
 
-            ( Done _ _, Done _ (StorageNoRationale { description }), _ ) ->
+            ( Done _ _, Done _ StorageNoRationale, _ ) ->
                 div []
                     [ Helper.sectionTitle "Vote Rationale"
-                    , Helper.stepNotAvailableCard [ text description ]
+                    , Helper.stepNotAvailableCard [ text (storageConfigDescription StorageNoRationale) ]
                     ]
 
             ( Done _ proposal, Done _ storageConfig, Preparing form ) ->
@@ -5136,10 +5134,10 @@ viewRationaleSignatureStep ctx pickProposalStep storageConfigStep rationaleCreat
     div []
         [ Helper.sectionTitle "Rationale Signature" -- Always show the title
         , case storageConfigStep of
-            Done _ (StoragePrepublished _) ->
+            Done _ StoragePrepublished ->
                 Helper.stepNotAvailableCard [ text "Rationale is already published." ]
 
-            Done _ (StorageNoRationale _) ->
+            Done _ StorageNoRationale ->
                 Helper.stepNotAvailableCard [ text "No rationale." ]
 
             _ ->
@@ -5382,14 +5380,14 @@ viewPermanentStorageStep ctx pickProposalStep rationaleSignatureStep storageConf
         div []
             [ Helper.sectionTitle "Rationale Storage"
             , case ( storageConfigStep, rationaleSignatureStep, step ) of
-                ( Done _ (StorageNoRationale _), _, _ ) ->
+                ( Done _ StorageNoRationale, _, _ ) ->
                     Helper.cardContainer []
                         [ Helper.cardHeader [] "Step Not Available" "" []
                         , Helper.cardContent []
                             [ Html.p [] [ text "No rationale." ] ]
                         ]
 
-                ( Done _ (StoragePrepublished _), _, Preparing form ) ->
+                ( Done _ StoragePrepublished, _, Preparing form ) ->
                     div []
                         [ Helper.cardContainer []
                             [ Helper.cardHeader [] "Verify Published Rationale" "" []
@@ -5406,7 +5404,7 @@ viewPermanentStorageStep ctx pickProposalStep rationaleSignatureStep storageConf
                             [ Helper.viewButton "Check Rationale URI" CheckRationaleUrlButtonClicked ]
                         ]
 
-                ( Done _ (StorageCustomHosting _), Done _ _, Preparing form ) ->
+                ( Done _ StorageCustomHosting, Done _ _, Preparing form ) ->
                     div []
                         [ Helper.cardContainer []
                             [ Helper.cardHeader [] "Verify Published Rationale" "" []
@@ -5431,7 +5429,7 @@ viewPermanentStorageStep ctx pickProposalStep rationaleSignatureStep storageConf
                 ( Done _ _, _, Validating _ _ ) ->
                     Helper.uploadingSpinner "Checking rationale storage..."
 
-                ( Done _ (StoragePrepublished _), _, Done _ storage ) ->
+                ( Done _ StoragePrepublished, _, Done _ storage ) ->
                     case pickProposalStep of
                         Done _ { id } ->
                             viewCompletedStorage ctx.ipfsPreconfig (Just id) storage
@@ -5708,10 +5706,10 @@ viewMissingStepsMessage model =
     let
         isRationaleAppCreated =
             case model.storageConfigStep of
-                Done _ (StoragePrepublished _) ->
+                Done _ StoragePrepublished ->
                     False
 
-                Done _ (StorageNoRationale _) ->
+                Done _ StorageNoRationale ->
                     False
 
                 _ ->
@@ -5719,7 +5717,7 @@ viewMissingStepsMessage model =
 
         hasRationale =
             case model.storageConfigStep of
-                Done _ (StorageNoRationale _) ->
+                Done _ StorageNoRationale ->
                     False
 
                 _ ->


### PR DESCRIPTION
In order to solve #164 in two steps, this is a first step that enables selecting multiple IPFS providers instead of limiting to a single provider. When selecting the "Publish to IPFS" mode now, you can select multiple options, each will display its own configuration.


<img width="991" height="1051" alt="image" src="https://github.com/user-attachments/assets/51cb73f9-73ca-4c35-b017-33f6cd1bc436" />


Picking one of the other options does not require any further setup, and is incompatible with the "Publish to IPFS" option.


<img width="870" height="395" alt="image" src="https://github.com/user-attachments/assets/d6d5d159-30da-45a5-8fdc-789909c3107e" />


For both the auto-published PDF, or the final rationale publication, if at least one of the method succeeds, the step is validated. However, partial failures will still be displayed to inform the user.


<img width="965" height="897" alt="image" src="https://github.com/user-attachments/assets/2d388153-9dff-4759-8c1b-5e910d8330a8" />


This does not tackle yet other aspects of the request in issue #164 
In particular:
- adding filecoin option to blockfrost (without the PDF)
- enabling multiple pre-configured options instead of a single one