### PR TITLE
Fix counting of votes

### DIFF
--- a/frontend/src/Page/Cart.elm
+++ b/frontend/src/Page/Cart.elm
@@ -951,7 +951,7 @@ buildTx costModels localStateUtxos walletAddress votersIntents hlabsIncentive =
             Dict.fromList (feePayer ++ voterKeys)
 
         message =
-            case List.length allVoteIntents of
+            case countAllVotersVotes votersIntents of
                 1 ->
                     "cfvt: 1 vote"
 


### PR DESCRIPTION
Fix #172 

The `cfvt: N vote(s)` metadata message was counting voters instead of votes, because `allVoteIntents` bundles all of a voter's votes into a single `TxIntent.Vote`. A DRep voting on 5 actions would show "1 vote".

Switched to `countAllVotersVotes votersIntents`, matching what the cart UI already displays.