### PR TITLE
Enable multiple pre-configured IPFS provider on the server

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,18 +1,52 @@
-# Regular IPFS RPC config with basic auth
-IPFS_FORMAT=basic
-IPFS_RPC_URL=https://ipfs-rpc.mycompany.org/api/v0
-IPFS_USER_ID=user
-IPFS_PASSWORD=password
-IPFS_LABEL="Pre-configured IPFS server"
-IPFS_DESCRIPTION="Files will be stored using the pre-configured IPFS servers."
+# IPFS preconfigs: a JSON array of pre-configured IPFS providers the frontend
+# will offer to users. Each entry must contain:
+#   - id          : stable slug used by the frontend to identify the entry
+#   - label       : short human-readable name shown in the UI
+#   - description : longer explanation shown next to the label
+#   - format      : "basic" | "nmkr" | "blockfrost"
+#
+# Per-format additional fields:
+#   basic      : rpcUrl, userId, password
+#   nmkr       : rpcUrl, userId, bearerToken
+#   blockfrost : projectId   (rpcUrl optional; defaults to https://ipfs.blockfrost.io/api/v0)
+#
+# Only id/label/description are exposed to the frontend; secrets stay here.
+IPFS_PRECONFIGS_JSON="[
+  { \"id\": \"default\"
+  , \"label\": \"Pre-configured IPFS server\"
+  , \"description\": \"Files will be stored using the pre-configured IPFS servers.\"
+  , \"format\": \"basic\"
+  , \"rpcUrl\": \"https://ipfs-rpc.mycompany.org/api/v0\"
+  , \"userId\": \"user\"
+  , \"password\": \"password\"
+  }
+]"
 
-# Alternative IPFS config using NMKR servers
-# IPFS_FORMAT=nmkr
-# IPFS_RPC_URL=https://studio-api.nmkr.io/v2/UploadToIpfs
-# IPFS_USER_ID=000000
-# IPFS_BEARER_TOKEN=ffffffffffffffffffffffffffffffff
-# IPFS_LABEL="Pre-configured IPFS server (sponsored by NMKR)"
-# IPFS_DESCRIPTION="Files will be stored using NMKR's IPFS servers."
+# Example with multiple preconfigs (NMKR + basic + Blockfrost):
+# IPFS_PRECONFIGS_JSON="[
+#   { \"id\": \"nmkr\"
+#   , \"label\": \"Pre-configured IPFS server (sponsored by NMKR)\"
+#   , \"description\": \"Files will be stored using NMKR servers.\"
+#   , \"format\": \"nmkr\"
+#   , \"rpcUrl\": \"https://studio-api.nmkr.io/v2/UploadToIpfs\"
+#   , \"userId\": \"000000\"
+#   , \"bearerToken\": \"ffffffffffffffffffffffffffffffff\"
+#   },
+#   { \"id\": \"cf\"
+#   , \"label\": \"Cardano Foundation IPFS\"
+#   , \"description\": \"Pinned by the Cardano Foundation IPFS cluster.\"
+#   , \"format\": \"basic\"
+#   , \"rpcUrl\": \"https://ipfs-rpc.mycompany.org/api/v0\"
+#   , \"userId\": \"user\"
+#   , \"password\": \"password\"
+#   },
+#   { \"id\": \"blockfrost\"
+#   , \"label\": \"Blockfrost IPFS\"
+#   , \"description\": \"Pinned via Blockfrost's IPFS service.\"
+#   , \"format\": \"blockfrost\"
+#   , \"projectId\": \"ipfsXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"
+#   }
+# ]"
 
 # Matomo Analytics
 MATOMO_URL="https://cardanofoundation.matomo.cloud/"

--- a/backend/.env.example2
+++ b/backend/.env.example2
@@ -1,22 +1,26 @@
-# Regular IPFS RPC config with basic auth
-IPFS_FORMAT=basic
-IPFS_RPC_URL=https://ipfs-rpc.mycompany.org/api/v0
-IPFS_USER_ID=user
-IPFS_PASSWORD=password
-IPFS_LABEL="Pre-configured IPFS server"
-IPFS_DESCRIPTION="Files will be stored using the pre-configured IPFS servers."
-
-# Alternative IPFS config using NMKR servers
-# IPFS_FORMAT=nmkr
-# IPFS_RPC_URL=https://studio-api.nmkr.io/v2/UploadToIpfs
-# IPFS_USER_ID=000000
-# IPFS_BEARER_TOKEN=ffffffffffffffffffffffffffffffff
-# IPFS_LABEL="Pre-configured IPFS server (sponsored by NMKR)"
-# IPFS_DESCRIPTION="Files will be stored using NMKR's IPFS servers."
+# IPFS preconfigs: a JSON array of pre-configured IPFS providers the frontend
+# will offer to users. Each entry must contain:
+#   - id          : stable slug used by the frontend to identify the entry
+#   - label       : short human-readable name shown in the UI
+#   - description : longer explanation shown next to the label
+#   - format      : "basic" | "nmkr" | "blockfrost"
+#
+# Per-format additional fields:
+#   basic      : rpcUrl, userId, password
+#   nmkr       : rpcUrl, userId, bearerToken
+#   blockfrost : projectId   (rpcUrl optional; defaults to https://ipfs.blockfrost.io/api/v0)
+#
+# Only id/label/description are exposed to the frontend; secrets stay here.
+IPFS_PRECONFIGS_JSON="[
+  { \"id\": \"default\"
+  , \"label\": \"Pre-configured IPFS server\"
+  , \"description\": \"Files will be stored using the pre-configured IPFS servers.\"
+  , \"format\": \"basic\"
+  , \"rpcUrl\": \"https://ipfs-rpc.mycompany.org/api/v0\"
+  , \"userId\": \"user\"
+  , \"password\": \"password\"
+  }
+]"
 
 # Network config: 0 for Preview, 1 for Mainnet
 NETWORK_ID=0
-
-# Preconfiguration of some voters for fast selection
-# PRECONFIGURED_VOTERS_JSON=[{"voterType":"DRep","description":"Vote as a Delegated Representative","govId":"drep1ydpfkyjxzeqvalf6fgvj7lznrk8kcmfnvy9hyl6gr6ez6wgsjaelx"},{"voterType":"CC Member","description":"Vote as a Constitutional Committee Member","govId":"cc_hot1qdnedkra2957t6xzzwygdgyefd5ctpe4asywauqhtzlu9qqkttvd9"},{"voterType":"SPO","description":"Vote as a Stake Pool Operator","govId":"pool1nqheyct9a0mxn80cwp9pd5guncfu3rzwqtmru0l94accz7gjcgl"}]
-

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,23 +1,23 @@
+import base64
 import json
 import logging
+import mimetypes
 import os
 import shutil
-import base64
 import subprocess
 import tempfile
-import mimetypes
+from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import List, Optional, Tuple, Dict
+from typing import Dict, List, Optional, Tuple
 
 import httpx
-from pydantic import BaseModel
+from brotli_asgi import BrotliMiddleware
 from dotenv import load_dotenv
-from fastapi import Body, FastAPI, HTTPException, UploadFile, Request
-from fastapi.responses import HTMLResponse, Response, FileResponse
+from fastapi import Body, FastAPI, HTTPException, Request, UploadFile
+from fastapi.responses import FileResponse, HTMLResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from contextlib import asynccontextmanager
-from brotli_asgi import BrotliMiddleware
+from pydantic import BaseModel
 
 TIMEOUT_SECONDS = 10
 MAX_CONCURRENT_REQUESTS = 100
@@ -29,55 +29,90 @@ logger = logging.getLogger(__name__)
 # Load environment variables from .env file
 load_dotenv()
 
-# Check for basic auth format completeness
-basic_auth_vars = ["IPFS_RPC_URL", "IPFS_USER_ID", "IPFS_PASSWORD"]
-basic_auth_missing = [var for var in basic_auth_vars if not os.getenv(var)]
-basic_auth_complete = len(basic_auth_missing) == 0
-
-# Check for nmkr format completeness
-nmkr_auth_vars = ["IPFS_RPC_URL", "IPFS_USER_ID", "IPFS_BEARER_TOKEN"]
-nmkr_auth_missing = [var for var in nmkr_auth_vars if not os.getenv(var)]
-nmkr_auth_complete = len(nmkr_auth_missing) == 0
-
-# Only show warnings if both formats are incomplete
-if not basic_auth_complete and not nmkr_auth_complete:
-    logger.warning(
-        "Neither basic nor nmkr IPFS authentication is completely configured."
-    )
-    if basic_auth_missing:
-        logger.warning(f"Basic auth missing: {', '.join(basic_auth_missing)}")
-    if nmkr_auth_missing:
-        logger.warning(f"Nmkr auth missing: {', '.join(nmkr_auth_missing)}")
-    logger.warning("All IPFS requests will need to provide RPC config or will fail")
-
 # Check for NETWORK_ID
 NETWORK_ID = os.getenv("NETWORK_ID", "0")  # defaults to 0 if not set
 if not os.getenv("NETWORK_ID"):
     logger.warning("NETWORK_ID not set, using default value of 0 (Preview)")
 
-# Check if using Nmkr format - default to basic if both are available
-IPFS_FORMAT = os.getenv("IPFS_FORMAT", "basic").lower()
-if IPFS_FORMAT not in ["basic", "nmkr"]:
-    logger.warning(f"Unknown IPFS_FORMAT '{IPFS_FORMAT}', defaulting to 'basic'")
-    IPFS_FORMAT = "basic"
 
-# If the configured format is incomplete but the other one is complete, use the complete one
-if IPFS_FORMAT == "basic" and not basic_auth_complete and nmkr_auth_complete:
-    logger.info("Basic auth incomplete but nmkr auth complete. Using nmkr format.")
-    IPFS_FORMAT = "nmkr"
-elif IPFS_FORMAT == "nmkr" and not nmkr_auth_complete and basic_auth_complete:
-    logger.info("Nmkr auth incomplete but basic auth complete. Using basic format.")
-    IPFS_FORMAT = "basic"
+BLOCKFROST_DEFAULT_RPC_URL = "https://ipfs.blockfrost.io/api/v0"
 
-# Set variables for selected format
-IPFS_USER_ID = os.getenv("IPFS_USER_ID", "")
-IPFS_PASSWORD = os.getenv("IPFS_PASSWORD", "")
-IPFS_BEARER_TOKEN = os.getenv("IPFS_BEARER_TOKEN", "")
 
-# Set variables for the IPFS server textual description
-IPFS_LABEL = os.getenv("IPFS_LABEL", "Pre-configured IPFS server")
-IPFS_DESCRIPTION = os.getenv(
-    "IPFS_DESCRIPTION", "Files will be pinned using the pre-configured IPFS server."
+# Build the list of pre-configured IPFS providers.
+#
+# IPFS_PRECONFIGS_JSON contains a JSON list of objects.
+# Common fields: id, label, description, format ("basic" | "nmkr" | "blockfrost").
+# Per-format additional fields:
+#   basic      : rpcUrl, userId, password
+#   nmkr       : rpcUrl, userId, bearerToken
+#   blockfrost : projectId (rpcUrl optional; defaults to Blockfrost's public host)
+def _validate_preconfig(entry: dict, index: int) -> dict:
+    common = ["id", "label", "description", "format"]
+    for key in common:
+        if not entry.get(key):
+            raise Exception(f"IPFS preconfig #{index}: missing or empty field '{key}'")
+    fmt = entry["format"].lower()
+    if fmt not in ("basic", "nmkr", "blockfrost"):
+        raise Exception(
+            f"IPFS preconfig #{index} ('{entry['id']}'): unknown format '{fmt}'"
+        )
+    entry["format"] = fmt
+
+    def _require(key: str) -> None:
+        if not entry.get(key):
+            raise Exception(
+                f"IPFS preconfig #{index} ('{entry['id']}'): "
+                f"format '{fmt}' requires '{key}'"
+            )
+
+    if fmt == "basic":
+        for key in ("rpcUrl", "userId", "password"):
+            _require(key)
+    elif fmt == "nmkr":
+        for key in ("rpcUrl", "userId", "bearerToken"):
+            _require(key)
+    elif fmt == "blockfrost":
+        _require("projectId")
+        # rpcUrl is optional for blockfrost — fall back to the public endpoint.
+        if not entry.get("rpcUrl"):
+            entry["rpcUrl"] = BLOCKFROST_DEFAULT_RPC_URL
+    return entry
+
+
+IPFS_PRECONFIGS_JSON_RAW = os.getenv("IPFS_PRECONFIGS_JSON", "").strip()
+IPFS_PRECONFIGS: List[dict] = []
+if IPFS_PRECONFIGS_JSON_RAW:
+    try:
+        parsed = json.loads(IPFS_PRECONFIGS_JSON_RAW)
+    except Exception as e:
+        raise Exception(f"Invalid JSON for IPFS_PRECONFIGS_JSON: {e}")
+    if not isinstance(parsed, list):
+        raise Exception("IPFS_PRECONFIGS_JSON must be a JSON array")
+    for index, entry in enumerate(parsed):
+        if not isinstance(entry, dict):
+            raise Exception(f"IPFS preconfig #{index} must be an object")
+        IPFS_PRECONFIGS.append(_validate_preconfig(entry, index))
+    seen_ids: set = set()
+    for entry in IPFS_PRECONFIGS:
+        if entry["id"] in seen_ids:
+            raise Exception(f"Duplicate IPFS preconfig id: '{entry['id']}'")
+        seen_ids.add(entry["id"])
+
+if not IPFS_PRECONFIGS:
+    logger.warning(
+        "No IPFS preconfig available (IPFS_PRECONFIGS_JSON is unset or empty). "
+        "All IPFS requests will need to provide a custom RPC config or will fail."
+    )
+
+# Indexed by id for fast lookup during pin requests.
+IPFS_PRECONFIGS_BY_ID: Dict[str, dict] = {p["id"]: p for p in IPFS_PRECONFIGS}
+
+# Public view exposed to the frontend (never includes secrets).
+IPFS_PRECONFIGS_PUBLIC_JSON = json.dumps(
+    [
+        {"id": p["id"], "label": p["label"], "description": p["description"]}
+        for p in IPFS_PRECONFIGS
+    ]
 )
 
 # Matomo Analytics
@@ -116,7 +151,7 @@ async def lifespan(app: FastAPI):
         timeout=httpx.Timeout(TIMEOUT_SECONDS),
         limits=httpx.Limits(max_connections=MAX_CONCURRENT_REQUESTS),
     ) as client:
-        app.async_client = client  # pyright: ignore
+        app.async_client = client  # type: ignore
         yield
 
 
@@ -138,8 +173,7 @@ async def read_root(request: Request):
         {
             "request": request,
             "network_id": NETWORK_ID,
-            "ipfs_label": IPFS_LABEL,
-            "ipfs_description": IPFS_DESCRIPTION,
+            "ipfs_preconfigs": IPFS_PRECONFIGS_PUBLIC_JSON,
             "preconfigured_voters": PRECONFIGURED_VOTERS_JSON,
             "preconfigured_authors": PRECONFIGURED_AUTHORS_JSON,
             "matomo_script": MATOMO_SCRIPT,
@@ -154,8 +188,7 @@ async def get_page(full_path: str, request: Request):
         {
             "request": request,
             "network_id": NETWORK_ID,
-            "ipfs_label": IPFS_LABEL,
-            "ipfs_description": IPFS_DESCRIPTION,
+            "ipfs_preconfigs": IPFS_PRECONFIGS_PUBLIC_JSON,
             "preconfigured_voters": PRECONFIGURED_VOTERS_JSON,
             "preconfigured_authors": PRECONFIGURED_AUTHORS_JSON,
             "matomo_script": MATOMO_SCRIPT,
@@ -244,7 +277,7 @@ async def create_pretty_pdf(data: dict = Body(...)):
 class IPFSPinRequest(BaseModel):
     ipfsServer: str | None = None
     headers: List[Tuple[str, str]] | None = None
-    userId: str | None = None  # user ID for both formats
+    preconfigId: str | None = None
 
 
 class IPFSPinJSONRequest(IPFSPinRequest):
@@ -252,58 +285,106 @@ class IPFSPinJSONRequest(IPFSPinRequest):
     jsonContent: str
 
 
+def _pick_preconfig(preconfig_id: Optional[str]) -> Optional[dict]:
+    if not IPFS_PRECONFIGS:
+        return None
+    if preconfig_id is None:
+        # Back-compat: when no id is supplied, use the first preconfig.
+        return IPFS_PRECONFIGS[0]
+    entry = IPFS_PRECONFIGS_BY_ID.get(preconfig_id)
+    if entry is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown IPFS preconfig id: '{preconfig_id}'",
+        )
+    return entry
+
+
 def get_ipfs_config(
-    request_user_id: Optional[str] = None,
+    preconfig_id: Optional[str] = None,
     ipfs_server: Optional[str] = None,
     custom_headers: Optional[List[Tuple[str, str]]] = None,
-) -> Tuple[str, Dict[str, str]]:
-    """Get the appropriate IPFS configuration based on request parameters or environment variables."""
+) -> Tuple[str, Dict[str, str], str]:
+    """Resolve the IPFS endpoint + auth headers and the effective format.
 
-    # Use default IPFS settings if not provided
-    server_url = ipfs_server or os.getenv("IPFS_RPC_URL") or ""
+    Precedence:
+      1. Explicit ipfs_server + custom_headers from the request (custom provider).
+      2. The named preconfig (preconfig_id).
+      3. The first available preconfig (back-compat).
+    """
 
-    # If custom headers are provided, use them (this overrides both formats)
+    # Explicit custom provider from the request: pass through as-is, format
+    # is assumed to be "basic" (kubo-style /add) for custom RPCs.
     if ipfs_server and custom_headers:
-        return server_url, dict(custom_headers)
+        return ipfs_server, dict(custom_headers), "basic"
 
-    # Handle different authentication formats
-    if IPFS_FORMAT == "nmkr":
-        # Use Nmkr format (user ID + bearer token)
-        user_id = request_user_id or IPFS_USER_ID
-        bearer_token = os.getenv("IPFS_BEARER_TOKEN", "")
+    entry = _pick_preconfig(preconfig_id)
+    if entry is None:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "No IPFS preconfig is available on the server and no custom "
+                "IPFS server was provided in the request."
+            ),
+        )
 
-        # For Nmkr, the URL ends with the user ID
+    server_url = entry["rpcUrl"]
+    fmt = entry["format"]
+
+    if fmt == "nmkr":
+        user_id = entry["userId"]
+        bearer_token = entry["bearerToken"]
         if not server_url.endswith(f"/{user_id}"):
             server_url = f"{server_url}/{user_id}"
+        return (
+            server_url,
+            {
+                "Authorization": f"Bearer {bearer_token}",
+                "Accept": "application/json",
+            },
+            fmt,
+        )
 
-        return server_url, {
-            "Authorization": f"Bearer {bearer_token}",
-            "Accept": "application/json",
-        }
+    if fmt == "blockfrost":
+        return (
+            server_url,
+            {
+                "project_id": entry["projectId"],
+                "Accept": "application/json",
+            },
+            fmt,
+        )
+
     else:
         # Default to basic auth format
-        user_id = request_user_id or IPFS_USER_ID
-        password = IPFS_PASSWORD
+        user_id = entry["userId"]
+        password = entry["password"]
         auth_string = f"{user_id}:{password}"
         token = base64.b64encode(auth_string.encode("utf-8")).decode("ascii")
-        return server_url, {
-            "Authorization": f"Basic {token}",
-            "Accept": "application/json",
-        }
+        return (
+            server_url,
+            {
+                "Authorization": f"Basic {token}",
+                "Accept": "application/json",
+            },
+            fmt,
+        )
 
 
 async def pin_to_ipfs_common(
     temp_file_path: Path,
     ipfs_server: Optional[str] = None,
     custom_headers: Optional[List[Tuple[str, str]]] = None,
-    user_id: Optional[str] = None,
+    preconfig_id: Optional[str] = None,
 ):
     """Common IPFS pinning logic used by both endpoints."""
     try:
-        server_url, headers = get_ipfs_config(user_id, ipfs_server, custom_headers)
+        server_url, headers, ipfs_format = get_ipfs_config(
+            preconfig_id, ipfs_server, custom_headers
+        )
 
         # Different handling based on format
-        if IPFS_FORMAT == "nmkr":
+        if ipfs_format == "nmkr":
             # For Nmkr format, we need to convert file to base64 and include metadata
             file_name = temp_file_path.name
 
@@ -338,6 +419,59 @@ async def pin_to_ipfs_common(
                 media_type=response.headers.get("content-type"),
             )
 
+        elif ipfs_format == "blockfrost":
+            # Blockfrost IPFS: /ipfs/add returns the CID but does not pin.
+            # We then call /ipfs/pin/add/{cid} to actually pin. The frontend's
+            # IpfsAnswer decoder reads `ipfs_hash` from the /add response, so
+            # we return that body whether or not the pin step succeeds — the
+            # status code reflects pin failure when applicable.
+            with open(temp_file_path, "rb") as f:
+                add_response = await app.async_client.post(  # type: ignore
+                    url=f"{server_url}/ipfs/add",
+                    headers=headers,
+                    files={"file": f},
+                )
+
+            if add_response.status_code != 200:
+                return Response(
+                    content=add_response.content,
+                    status_code=add_response.status_code,
+                    media_type=add_response.headers.get("content-type"),
+                )
+
+            try:
+                cid = add_response.json()["ipfs_hash"]
+            except (KeyError, json.JSONDecodeError) as e:
+                logger.error(f"Blockfrost /add returned no ipfs_hash: {e}")
+                raise HTTPException(
+                    status_code=502,
+                    detail="Blockfrost IPFS add response missing ipfs_hash",
+                )
+
+            pin_response = await app.async_client.post(  # type: ignore
+                url=f"{server_url}/ipfs/pin/add/{cid}",
+                headers=headers,
+            )
+
+            if pin_response.status_code != 200:
+                logger.warning(
+                    "Blockfrost pin/add failed for CID %s (status %s): %s",
+                    cid,
+                    pin_response.status_code,
+                    pin_response.text,
+                )
+                return Response(
+                    content=pin_response.content,
+                    status_code=pin_response.status_code,
+                    media_type=pin_response.headers.get("content-type"),
+                )
+
+            return Response(
+                content=add_response.content,
+                status_code=add_response.status_code,
+                media_type=add_response.headers.get("content-type"),
+            )
+
         else:
             # Basic format - uses /add endpoint with file upload
             with open(temp_file_path, "rb") as f:
@@ -362,6 +496,8 @@ async def pin_to_ipfs_common(
                     media_type=add_response.headers.get("content-type"),
                 )
 
+    except HTTPException:
+        raise
     except json.JSONDecodeError as e:
         logger.error(f"Failed to parse IPFS output: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to parse IPFS response")
@@ -374,10 +510,13 @@ async def pin_to_ipfs_common(
 async def pin_file_to_ipfs(
     file: UploadFile,
     ipfs_server: Optional[str] = None,
-    headers: Optional[List[Tuple[str, str]]] = None,
-    user_id: Optional[str] = None,
+    preconfig_id: Optional[str] = None,
 ):
-    """Pin a file to IPFS and return the hash."""
+    """Pin a file to IPFS and return the hash.
+
+    When `ipfs_server` is not provided, `preconfig_id` selects which
+    pre-configured IPFS provider to use (defaults to the first one).
+    """
     logger.info("IPFS file pin attempt")
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -387,7 +526,12 @@ async def pin_file_to_ipfs(
         with open(temp_file_path, "wb") as f:
             f.write(content)
 
-        return await pin_to_ipfs_common(temp_file_path, ipfs_server, headers, user_id)
+        return await pin_to_ipfs_common(
+            temp_file_path,
+            ipfs_server=ipfs_server,
+            custom_headers=None,
+            preconfig_id=preconfig_id,
+        )
 
 
 @app.post("/ipfs-pin/json")
@@ -403,9 +547,9 @@ async def pin_json_to_ipfs(request: IPFSPinJSONRequest):
 
         return await pin_to_ipfs_common(
             temp_file_path,
-            request.ipfsServer,
-            request.headers,
-            request.userId,
+            ipfs_server=request.ipfsServer,
+            custom_headers=request.headers,
+            preconfig_id=request.preconfigId,
         )
 
 
@@ -430,7 +574,7 @@ async def proxy_request(request: ProxyRequest):
         }
 
         # Make the request
-        response = await app.async_client.request(  # pyright: ignore
+        response = await app.async_client.request(  # type: ignore
             method=request.method,
             url=request.url,
             headers={**default_headers, **request.headers},
@@ -459,7 +603,7 @@ class CompressedStaticFiles(StaticFiles):
                 accept_encoding = value.decode()
                 break
 
-        full_path = os.path.join(self.directory, path)  # pyright: ignore
+        full_path = os.path.join(self.directory, path)  # type: ignore
 
         # Serve Brotli (.br) if supported and available
         if "br" in accept_encoding and os.path.exists(full_path + ".br"):

--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -64,7 +64,7 @@ type alias ApiProvider msg =
     , ipfsAddFileCustom : { rpc : String, headers : List ( String, String ), file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
     , ipfsAddFileNmkr : { userId : String, apiToken : String, file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
     , ipfsAddFileBlockfrost : { projectId : String, file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
-    , ipfsAddFile : { file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
+    , ipfsAddFile : { id : String, file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
     , convertToPdf : String -> (Result Http.Error ElmBytes.Bytes -> msg) -> Cmd msg
     , getFromIpfsGateway : (Result Http.Error String -> msg) -> String -> String -> Cmd msg
     , verifyCip100Metadata : String -> (Result Http.Error Cip100VerificationResponse -> msg) -> Cmd msg
@@ -866,13 +866,14 @@ defaultApiProvider =
                 |> Task.andThen (pinRequest projectId)
                 |> Task.attempt toMsg
 
-    -- Make a request to the pre-configured IPFS RPC via the server
+    -- Make a request to the pre-configured IPFS RPC via the server.
+    -- `id` selects which pre-configured provider on the backend to use.
     , ipfsAddFile =
-        \{ file } toMsg ->
+        \{ id, file } toMsg ->
             Http.request
                 { method = "POST"
                 , headers = []
-                , url = "/ipfs-pin/file"
+                , url = "/ipfs-pin/file?preconfig_id=" ++ Url.percentEncode id
                 , body = Http.multipartBody [ Http.filePart "file" file ]
                 , expect = Http.expectStringResponse toMsg responseToIpfsAnswer
                 , timeout = Nothing

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -78,7 +78,7 @@ import Page.Cart
 import Page.Disclaimer
 import Page.MultisigRegistration
 import Page.Pdf
-import Page.Preparation exposing (JsonLdContexts, StorageConfig)
+import Page.Preparation exposing (IpfsPreconfig, JsonLdContexts, StorageConfig)
 import Page.Signing
 import Platform.Cmd as Cmd
 import ProposalMetadata exposing (ProposalMetadata)
@@ -94,7 +94,7 @@ type alias Flags =
     , jsonLdContexts : JsonLdContexts
     , db : Value
     , networkId : Int
-    , ipfsPreconfig : { label : String, description : String }
+    , ipfsPreconfig : IpfsPreconfig
     , voterPreconfig : List PreconfVoter
     , authorPreconfig : List PreconfAuthor
     }
@@ -199,7 +199,7 @@ type alias Model =
     , taskPool : ConcurrentTask.Pool Msg
     , db : Value
     , networkId : NetworkId
-    , ipfsPreconfig : { label : String, description : String }
+    , ipfsPreconfig : IpfsPreconfig
     , voterPreconfig : List PreconfVoter
     , authorPreconfig : List PreconfAuthor
     , cart : Page.Cart.Model
@@ -282,7 +282,7 @@ type alias ModelConfig =
     { jsonLdContexts : JsonLdContexts
     , db : Value
     , networkId : NetworkId
-    , ipfsPreconfig : { label : String, description : String }
+    , ipfsPreconfig : IpfsPreconfig
     , voterPreconfig : List PreconfVoter
     , authorPreconfig : List PreconfAuthor
     }
@@ -1027,7 +1027,7 @@ handleUrlChange route model =
                 newModel =
                     { model
                         | errors = []
-                        , page = PreparationPage Page.Preparation.init
+                        , page = PreparationPage (Page.Preparation.init model.ipfsPreconfig)
                         , appUrl = appUrl
                         , pendingProposalId = proposalId
                     }
@@ -1042,8 +1042,8 @@ handleUrlChange route model =
 
                 reloadLatestStorageConfigTask : ConcurrentTask String StorageConfig
                 reloadLatestStorageConfigTask =
-                    Storage.read { db = model.db, storeName = "app" } Page.Preparation.storageConfigDecoder { key = "lastStorageConfig" }
-                        |> ConcurrentTask.onError (\_ -> ConcurrentTask.succeed Page.Preparation.initStorageConfig)
+                    Storage.read { db = model.db, storeName = "app" } (Page.Preparation.storageConfigDecoder model.ipfsPreconfig) { key = "lastStorageConfig" }
+                        |> ConcurrentTask.onError (\_ -> ConcurrentTask.succeed (Page.Preparation.initStorageConfig model.ipfsPreconfig))
 
                 ( newTaskPool, taskCmds ) =
                     ConcurrentTask.attemptEach { pool = model.taskPool, send = sendTask, onComplete = OnTaskComplete }

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -128,14 +128,26 @@ type Cip100VerificationState
     | VerificationError String
 
 
-init : Model
-init =
+init : IpfsPreconfig -> Model
+init ipfsPreconfig =
+    let
+        -- When at least one preconfig is available, mark the step Done so the
+        -- user can skip storage configuration. Without any preconfig there's
+        -- no sensible default and we force the user through the form.
+        initialStorageStep =
+            case ipfsPreconfig of
+                _ :: _ ->
+                    Done initStorageConfigForm (initStorageConfig ipfsPreconfig)
+
+                [] ->
+                    Preparing initStorageConfigForm
+    in
     Model
         { someRefUtxos = Utxo.emptyRefDict
         , reloadedLastVoter = False
         , voterStep = Preparing initVoterForm
         , pickProposalStep = Preparing {}
-        , storageConfigStep = Done initStorageConfigForm (StorageIpfs [ PreconfigIpfs ])
+        , storageConfigStep = initialStorageStep
         , rationaleCreationStep = Preparing initRationaleForm
         , rationaleSignatureStep = Preparing initRationaleSignatureForm
         , permanentStorageStep = Preparing initStorageForm
@@ -385,9 +397,14 @@ type StorageMode
 
 {-| Identifies an IPFS publish provider. Used as a key for tracking selection,
 upload progress, and per-provider error reporting.
+
+For `PreconfigKind` we carry the preconfig id so multiple pre-configured
+servers stay distinct in the publish set, upload-progress lists, and the
+per-provider error reporting.
+
 -}
 type ProviderKind
-    = PreconfigKind
+    = PreconfigKind String
     | BlockfrostKind
     | NmkrKind
     | CustomIpfsKind
@@ -424,7 +441,7 @@ type alias StorageConfigForm =
 initStorageConfigForm : StorageConfigForm
 initStorageConfigForm =
     { mode = ModeIpfs
-    , publishSet = [ PreconfigKind ]
+    , publishSet = []
     , nmkrUserId = ""
     , nmkrApiToken = ""
     , blockfrostProjectId = ""
@@ -455,8 +472,8 @@ formFromStorageConfig config =
 applyProviderToForm : IpfsProvider -> StorageConfigForm -> StorageConfigForm
 applyProviderToForm provider form =
     case provider of
-        PreconfigIpfs ->
-            { form | publishSet = PreconfigKind :: form.publishSet }
+        PreconfigIpfs { id } ->
+            { form | publishSet = PreconfigKind id :: form.publishSet }
 
         BlockfrostIpfs { projectId } ->
             { form
@@ -482,10 +499,10 @@ applyProviderToForm provider form =
 {-| One of the IPFS providers the rationale can be published to.
 The user-facing label and description for each variant are not stored
 on the variant itself; they are derived at view time from `ProviderKind`
-(and, for `PreconfigIpfs`, from the app-init `IpfsPreconfig`).
+(and, for `PreconfigIpfs`, from the app-init `IpfsPreconfig` list).
 -}
 type IpfsProvider
-    = PreconfigIpfs
+    = PreconfigIpfs { id : String }
     | BlockfrostIpfs { projectId : String }
     | NmkrIpfs { userId : String, apiToken : String }
     | CustomIpfsProvider { ipfsServer : String, headers : List ( String, String ) }
@@ -494,8 +511,8 @@ type IpfsProvider
 providerKind : IpfsProvider -> ProviderKind
 providerKind provider =
     case provider of
-        PreconfigIpfs ->
-            PreconfigKind
+        PreconfigIpfs { id } ->
+            PreconfigKind id
 
         BlockfrostIpfs _ ->
             BlockfrostKind
@@ -514,11 +531,15 @@ type StorageConfig
     | StorageNoRationale
 
 
-{-| Initialize the default storage config.
+{-| Initialize the default storage config: publish to every available IPFS preconfig.
+
+If the preconfig list is empty, the resulting `StorageIpfs []` is treated by
+the form-build step as "no provider selected".
+
 -}
-initStorageConfig : StorageConfig
-initStorageConfig =
-    StorageIpfs [ PreconfigIpfs ]
+initStorageConfig : IpfsPreconfig -> StorageConfig
+initStorageConfig ipfsPreconfig =
+    StorageIpfs (List.map (\{ id } -> PreconfigIpfs { id = id }) ipfsPreconfig)
 
 
 encodeStorageConfig : StorageConfig -> JE.Value
@@ -543,8 +564,11 @@ encodeStorageConfig config =
 encodeIpfsProvider : IpfsProvider -> JE.Value
 encodeIpfsProvider provider =
     case provider of
-        PreconfigIpfs ->
-            JE.object [ ( "type", JE.string "PreconfigIpfs" ) ]
+        PreconfigIpfs { id } ->
+            JE.object
+                [ ( "type", JE.string "PreconfigIpfs" )
+                , ( "id", JE.string id )
+                ]
 
         BlockfrostIpfs { projectId } ->
             JE.object
@@ -579,14 +603,19 @@ httpHeaderDecoder =
         (JD.field "value" JD.string)
 
 
-storageConfigDecoder : JD.Decoder StorageConfig
-storageConfigDecoder =
+{-| Decode a persisted `StorageConfig`. Needs the current `IpfsPreconfig` list
+to validate that `PreconfigIpfs` entries still match an available preconfig.
+The whole decoder fails if any provider can't be resolved; the caller falls
+back to `initStorageConfig` in that case.
+-}
+storageConfigDecoder : IpfsPreconfig -> JD.Decoder StorageConfig
+storageConfigDecoder ipfsPreconfig =
     JD.field "kind" JD.string
         |> JD.andThen
             (\kind ->
                 case kind of
                     "StorageIpfs" ->
-                        JD.field "providers" (JD.list ipfsProviderDecoder)
+                        JD.field "providers" (JD.list (ipfsProviderDecoder ipfsPreconfig))
                             |> JD.andThen
                                 (\providers ->
                                     if List.isEmpty providers then
@@ -610,14 +639,29 @@ storageConfigDecoder =
             )
 
 
-ipfsProviderDecoder : JD.Decoder IpfsProvider
-ipfsProviderDecoder =
+{-| Decode a single `IpfsProvider`. Fails if a `PreconfigIpfs` entry references
+an id that no longer matches any available preconfig.
+-}
+ipfsProviderDecoder : IpfsPreconfig -> JD.Decoder IpfsProvider
+ipfsProviderDecoder ipfsPreconfig =
+    let
+        knownIds =
+            List.map .id ipfsPreconfig
+    in
     JD.field "type" JD.string
         |> JD.andThen
             (\providerType ->
                 case providerType of
                     "PreconfigIpfs" ->
-                        JD.succeed PreconfigIpfs
+                        JD.field "id" JD.string
+                            |> JD.andThen
+                                (\id ->
+                                    if List.member id knownIds then
+                                        JD.succeed (PreconfigIpfs { id = id })
+
+                                    else
+                                        JD.fail ("Unknown IPFS preconfig id: " ++ id)
+                                )
 
                     "BlockfrostIpfs" ->
                         JD.map (\projectId -> BlockfrostIpfs { projectId = projectId })
@@ -835,8 +879,15 @@ type Msg
     | EndFlyAnim
 
 
+{-| The set of pre-configured IPFS providers exposed by the server.
+
+Each entry is identified by a stable `id` (a slug from the backend config).
+Only public metadata (label, description) is included; secrets such as API
+tokens stay on the backend and are looked up by id at upload time.
+
+-}
 type alias IpfsPreconfig =
-    { label : String, description : String }
+    List { id : String, label : String, description : String }
 
 
 {-| Configuration required by the update function.
@@ -2390,8 +2441,8 @@ buildIpfsProviders form =
     let
         buildProvider kind =
             case kind of
-                PreconfigKind ->
-                    Ok PreconfigIpfs
+                PreconfigKind id ->
+                    Ok (PreconfigIpfs { id = id })
 
                 BlockfrostKind ->
                     case String.trim form.blockfrostProjectId of
@@ -2696,10 +2747,10 @@ pinPdfFile fileAsValue (Model model) =
 uploadFileCmd : File -> IpfsProvider -> Cmd Msg
 uploadFileCmd file provider =
     case provider of
-        PreconfigIpfs ->
+        PreconfigIpfs { id } ->
             Api.defaultApiProvider.ipfsAddFile
-                { file = file }
-                (GotIpfsAnswer PreconfigKind)
+                { id = id, file = file }
+                (GotIpfsAnswer (PreconfigKind id))
 
         BlockfrostIpfs { projectId } ->
             Api.defaultApiProvider.ipfsAddFileBlockfrost
@@ -4505,13 +4556,16 @@ viewIpfsProviderSelection ctx form =
                 (List.member kind form.publishSet)
                 (IpfsProviderToggled kind)
 
+        preconfigKinds =
+            List.map (PreconfigKind << .id) ctx.ipfsPreconfig
+
         providerCards =
             Helper.nestedCard
                 { heading = "IPFS providers"
                 , sub = "Pick one or more. We upload to each. The step passes if any succeed."
                 }
                 [ Helper.viewGrid 240 <|
-                    List.map checkbox [ PreconfigKind, BlockfrostKind, NmkrKind, CustomIpfsKind ]
+                    List.map checkbox (preconfigKinds ++ [ BlockfrostKind, NmkrKind, CustomIpfsKind ])
                 ]
 
         providerConfig kind =
@@ -4525,26 +4579,31 @@ viewIpfsProviderSelection ctx form =
                 CustomIpfsKind ->
                     Just <| viewCustomIpfsForm form
 
-                _ ->
+                PreconfigKind _ ->
                     Nothing
     in
     div [] (providerCards :: (List.filterMap providerConfig <| List.sortBy ipfsProviderOrder form.publishSet))
 
 
-ipfsProviderOrder : ProviderKind -> Int
+{-| Order in which selected providers' config blocks render. Preconfigs are
+configured server-side and have no per-provider form, so they sort first
+(negative) to keep the layout stable when several are picked; the three
+external providers follow.
+-}
+ipfsProviderOrder : ProviderKind -> ( Int, String )
 ipfsProviderOrder kind =
     case kind of
+        PreconfigKind id ->
+            ( -1, id )
+
         BlockfrostKind ->
-            0
+            ( 0, "" )
 
         NmkrKind ->
-            1
+            ( 1, "" )
 
         CustomIpfsKind ->
-            2
-
-        _ ->
-            -1
+            ( 2, "" )
 
 
 viewBlockfrostForm : StorageConfigForm -> Html Msg
@@ -4678,7 +4737,7 @@ viewIpfsProviderInfo ipfsPreconfig provider =
             providerKindDescription ipfsPreconfig kind
     in
     case provider of
-        PreconfigIpfs ->
+        PreconfigIpfs _ ->
             defaultStorageConfigInfo label description
 
         BlockfrostIpfs { projectId } ->
@@ -4731,8 +4790,10 @@ viewIpfsProviderInfo ipfsPreconfig provider =
 providerKindLabel : IpfsPreconfig -> ProviderKind -> String
 providerKindLabel ipfsPreconfig kind =
     case kind of
-        PreconfigKind ->
-            ipfsPreconfig.label
+        PreconfigKind id ->
+            lookupPreconfig ipfsPreconfig id
+                |> Maybe.map .label
+                |> Maybe.withDefault ("Pre-configured IPFS (" ++ id ++ ")")
 
         BlockfrostKind ->
             "Blockfrost"
@@ -4747,8 +4808,10 @@ providerKindLabel ipfsPreconfig kind =
 providerKindDescription : IpfsPreconfig -> ProviderKind -> String
 providerKindDescription ipfsPreconfig kind =
     case kind of
-        PreconfigKind ->
-            ipfsPreconfig.description
+        PreconfigKind id ->
+            lookupPreconfig ipfsPreconfig id
+                |> Maybe.map .description
+                |> Maybe.withDefault "Pre-configured IPFS server (no longer available)."
 
         BlockfrostKind ->
             "Using Blockfrost IPFS server to store your files."
@@ -4758,6 +4821,11 @@ providerKindDescription ipfsPreconfig kind =
 
         CustomIpfsKind ->
             "Using a custom IPFS server configuration to store your files. The RPC should provide the /add?pin=true endpoint with answers equivalent to those described in the official kubo IPFS RPC docs: https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-add"
+
+
+lookupPreconfig : IpfsPreconfig -> String -> Maybe { id : String, label : String, description : String }
+lookupPreconfig ipfsPreconfig id =
+    List.Extra.find (\p -> p.id == id) ipfsPreconfig
 
 
 

--- a/frontend/static/index.html
+++ b/frontend/static/index.html
@@ -68,10 +68,7 @@
                 jsonLdContexts,
                 db,
                 networkId: {{network_id}}, // 0: Preview, 1: Mainnet
-                ipfsPreconfig: {
-                    label: {{ipfs_label|tojson}},
-                    description: {{ipfs_description|tojson}},
-                },
+                ipfsPreconfig: JSON.parse({{ipfs_preconfigs|tojson}}),
                 voterPreconfig: JSON.parse({{preconfigured_voters|tojson}}),
                 authorPreconfig: JSON.parse({{preconfigured_authors|tojson}}),
             },


### PR DESCRIPTION
Incremental work towards solving #164. The only thing left after is Filecoin support.

The backend's single pre-configured IPFS provider is replaced with a list of pre-configured providers and lets users publish rationales to several at once.

**Backend**
- New `IPFS_PRECONFIGS_JSON` env var: a JSON array of providers, each with `id`, `label`, `description`, `format` (`basic` | `nmkr` | `blockfrost`) plus per-format secrets. Validated at startup (required fields per format, unique ids); only public metadata (id/label/description) is exposed to the frontend.
- New `blockfrost` format: `/ipfs/add` followed by `/ipfs/pin/add/{cid}`.
- `/ipfs-pin/file` and `/ipfs-pin/json` take a `preconfig_id` to pick which preconfig to use (back-compat: defaults to the first one).
- Removes the old `IPFS_RPC_URL` / `IPFS_USER_ID` / `IPFS_PASSWORD` / `IPFS_BEARER_TOKEN` / `IPFS_FORMAT` / `IPFS_LABEL` / `IPFS_DESCRIPTION` variables.

**Frontend**
- Storage step shows a checkbox per pre-configured provider (alongside Blockfrost / NMKR / Custom). Multiple can be selected; the step succeeds if any upload succeeds.
- Default on first visit (or when persisted config fails to decode) is to check **all** pre-configured providers.
- `PreconfigIpfs` now carries the provider id; the persisted-config decoder validates ids against the current preconfig list and fails (falling back to defaults) if one is no longer available.