### PR TITLE
Enable filecoin storage via Blockfrost

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,6 +9,8 @@
 #   basic      : rpcUrl, userId, password
 #   nmkr       : rpcUrl, userId, bearerToken
 #   blockfrost : projectId   (rpcUrl optional; defaults to https://ipfs.blockfrost.io/api/v0)
+#                filecoin (optional, default false): when true, rationale JSON
+#                uploads can also be pinned to Filecoin via Blockfrost.
 #
 # Only id/label/description are exposed to the frontend; secrets stay here.
 IPFS_PRECONFIGS_JSON="[
@@ -45,6 +47,7 @@ IPFS_PRECONFIGS_JSON="[
 #   , \"description\": \"Pinned via Blockfrost's IPFS service.\"
 #   , \"format\": \"blockfrost\"
 #   , \"projectId\": \"ipfsXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"
+#   , \"filecoin\": true
 #   }
 # ]"
 

--- a/backend/.env.example2
+++ b/backend/.env.example2
@@ -9,6 +9,8 @@
 #   basic      : rpcUrl, userId, password
 #   nmkr       : rpcUrl, userId, bearerToken
 #   blockfrost : projectId   (rpcUrl optional; defaults to https://ipfs.blockfrost.io/api/v0)
+#                filecoin (optional, default false): when true, rationale JSON
+#                uploads can also be pinned to Filecoin via Blockfrost.
 #
 # Only id/label/description are exposed to the frontend; secrets stay here.
 IPFS_PRECONFIGS_JSON="[

--- a/backend/server.py
+++ b/backend/server.py
@@ -109,6 +109,7 @@ if not IPFS_PRECONFIGS:
 # Indexed by id for fast lookup during pin requests.
 IPFS_PRECONFIGS_BY_ID: Dict[str, dict] = {p["id"]: p for p in IPFS_PRECONFIGS}
 
+
 # Public view exposed to the frontend (never includes secrets).
 # `supportsFilecoin` is always included (default false) so the Elm flag
 # decoder can rely on the field being present.
@@ -117,9 +118,7 @@ def _public_view(p: dict) -> dict:
         "id": p["id"],
         "label": p["label"],
         "description": p["description"],
-        "supportsFilecoin": bool(
-            p.get("format") == "blockfrost" and p.get("filecoin")
-        ),
+        "supportsFilecoin": bool(p.get("format") == "blockfrost" and p.get("filecoin")),
     }
 
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -76,6 +76,8 @@ def _validate_preconfig(entry: dict, index: int) -> dict:
         # rpcUrl is optional for blockfrost — fall back to the public endpoint.
         if not entry.get("rpcUrl"):
             entry["rpcUrl"] = BLOCKFROST_DEFAULT_RPC_URL
+        # filecoin is optional; admin opt-in for Filecoin pinning of rationale JSON.
+        entry["filecoin"] = bool(entry.get("filecoin", False))
     return entry
 
 
@@ -108,12 +110,20 @@ if not IPFS_PRECONFIGS:
 IPFS_PRECONFIGS_BY_ID: Dict[str, dict] = {p["id"]: p for p in IPFS_PRECONFIGS}
 
 # Public view exposed to the frontend (never includes secrets).
-IPFS_PRECONFIGS_PUBLIC_JSON = json.dumps(
-    [
-        {"id": p["id"], "label": p["label"], "description": p["description"]}
-        for p in IPFS_PRECONFIGS
-    ]
-)
+# `supportsFilecoin` is always included (default false) so the Elm flag
+# decoder can rely on the field being present.
+def _public_view(p: dict) -> dict:
+    return {
+        "id": p["id"],
+        "label": p["label"],
+        "description": p["description"],
+        "supportsFilecoin": bool(
+            p.get("format") == "blockfrost" and p.get("filecoin")
+        ),
+    }
+
+
+IPFS_PRECONFIGS_PUBLIC_JSON = json.dumps([_public_view(p) for p in IPFS_PRECONFIGS])
 
 # Matomo Analytics
 MATOMO_URL = os.getenv("MATOMO_URL")
@@ -278,6 +288,7 @@ class IPFSPinRequest(BaseModel):
     ipfsServer: str | None = None
     headers: List[Tuple[str, str]] | None = None
     preconfigId: str | None = None
+    filecoin: bool = False
 
 
 class IPFSPinJSONRequest(IPFSPinRequest):
@@ -304,19 +315,23 @@ def get_ipfs_config(
     preconfig_id: Optional[str] = None,
     ipfs_server: Optional[str] = None,
     custom_headers: Optional[List[Tuple[str, str]]] = None,
-) -> Tuple[str, Dict[str, str], str]:
-    """Resolve the IPFS endpoint + auth headers and the effective format.
+    filecoin_requested: bool = False,
+) -> Tuple[str, Dict[str, str], str, bool]:
+    """Resolve the IPFS endpoint + auth headers, format, and effective Filecoin flag.
 
     Precedence:
       1. Explicit ipfs_server + custom_headers from the request (custom provider).
       2. The named preconfig (preconfig_id).
       3. The first available preconfig (back-compat).
+
+    The effective Filecoin flag is `True` only when the caller asks for it AND
+    the resolved provider is a Blockfrost preconfig that opted in via `filecoin: true`.
     """
 
     # Explicit custom provider from the request: pass through as-is, format
     # is assumed to be "basic" (kubo-style /add) for custom RPCs.
     if ipfs_server and custom_headers:
-        return ipfs_server, dict(custom_headers), "basic"
+        return ipfs_server, dict(custom_headers), "basic", False
 
     entry = _pick_preconfig(preconfig_id)
     if entry is None:
@@ -343,9 +358,11 @@ def get_ipfs_config(
                 "Accept": "application/json",
             },
             fmt,
+            False,
         )
 
     if fmt == "blockfrost":
+        use_filecoin = bool(filecoin_requested and entry.get("filecoin"))
         return (
             server_url,
             {
@@ -353,6 +370,7 @@ def get_ipfs_config(
                 "Accept": "application/json",
             },
             fmt,
+            use_filecoin,
         )
 
     else:
@@ -368,6 +386,7 @@ def get_ipfs_config(
                 "Accept": "application/json",
             },
             fmt,
+            False,
         )
 
 
@@ -376,11 +395,12 @@ async def pin_to_ipfs_common(
     ipfs_server: Optional[str] = None,
     custom_headers: Optional[List[Tuple[str, str]]] = None,
     preconfig_id: Optional[str] = None,
+    filecoin: bool = False,
 ):
     """Common IPFS pinning logic used by both endpoints."""
     try:
-        server_url, headers, ipfs_format = get_ipfs_config(
-            preconfig_id, ipfs_server, custom_headers
+        server_url, headers, ipfs_format, use_filecoin = get_ipfs_config(
+            preconfig_id, ipfs_server, custom_headers, filecoin_requested=filecoin
         )
 
         # Different handling based on format
@@ -448,9 +468,19 @@ async def pin_to_ipfs_common(
                     detail="Blockfrost IPFS add response missing ipfs_hash",
                 )
 
+            # Blockfrost expects both the query param and the JSON body.
+            # See https://blockfrost.dev/start-building/ipfs/
+            pin_url = f"{server_url}/ipfs/pin/add/{cid}"
+            if use_filecoin:
+                pin_url += "?filecoin=true"
             pin_response = await app.async_client.post(  # type: ignore
-                url=f"{server_url}/ipfs/pin/add/{cid}",
+                url=pin_url,
                 headers=headers,
+                json={
+                    "ipfs_hash": cid,
+                    "state": "queued",
+                    "filecoin": use_filecoin,
+                },
             )
 
             if pin_response.status_code != 200:
@@ -511,11 +541,14 @@ async def pin_file_to_ipfs(
     file: UploadFile,
     ipfs_server: Optional[str] = None,
     preconfig_id: Optional[str] = None,
+    filecoin: bool = False,
 ):
     """Pin a file to IPFS and return the hash.
 
     When `ipfs_server` is not provided, `preconfig_id` selects which
     pre-configured IPFS provider to use (defaults to the first one).
+    `filecoin=true` additionally pins to Filecoin via Blockfrost, but only
+    when the resolved preconfig is Blockfrost and was admin-opted-in.
     """
     logger.info("IPFS file pin attempt")
 
@@ -531,6 +564,7 @@ async def pin_file_to_ipfs(
             ipfs_server=ipfs_server,
             custom_headers=None,
             preconfig_id=preconfig_id,
+            filecoin=filecoin,
         )
 
 
@@ -550,6 +584,7 @@ async def pin_json_to_ipfs(request: IPFSPinJSONRequest):
             ipfs_server=request.ipfsServer,
             custom_headers=request.headers,
             preconfig_id=request.preconfigId,
+            filecoin=request.filecoin,
         )
 
 

--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -63,8 +63,8 @@ type alias ApiProvider msg =
     , getVotes : NetworkId -> Gov.Id -> (Result Http.Error (List OnchainVote) -> msg) -> Cmd msg
     , ipfsAddFileCustom : { rpc : String, headers : List ( String, String ), file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
     , ipfsAddFileNmkr : { userId : String, apiToken : String, file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
-    , ipfsAddFileBlockfrost : { projectId : String, file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
-    , ipfsAddFile : { id : String, file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
+    , ipfsAddFileBlockfrost : { projectId : String, filecoin : Bool, file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
+    , ipfsAddFile : { id : String, filecoin : Bool, file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
     , convertToPdf : String -> (Result Http.Error ElmBytes.Bytes -> msg) -> Cmd msg
     , getFromIpfsGateway : (Result Http.Error String -> msg) -> String -> String -> Cmd msg
     , verifyCip100Metadata : String -> (Result Http.Error Cip100VerificationResponse -> msg) -> Cmd msg
@@ -820,8 +820,8 @@ defaultApiProvider =
                     , timeout = Nothing
                     }
 
-            pinRequest : String -> IpfsAnswer -> Task String IpfsAnswer
-            pinRequest projectId ipfsAnswer =
+            pinRequest : String -> Bool -> IpfsAnswer -> Task String IpfsAnswer
+            pinRequest projectId filecoin ipfsAnswer =
                 case ipfsAnswer of
                     IpfsError _ ->
                         Task.succeed ipfsAnswer
@@ -830,13 +830,21 @@ defaultApiProvider =
                         Http.task
                             { method = "POST"
                             , headers = [ Http.header "project_id" projectId ]
-                            , url = "https://ipfs.blockfrost.io/api/v0/ipfs/pin/add/" ++ cid
+                            , url =
+                                "https://ipfs.blockfrost.io/api/v0/ipfs/pin/add/"
+                                    ++ cid
+                                    ++ (if filecoin then
+                                            "?filecoin=true"
+
+                                        else
+                                            ""
+                                       )
                             , body =
                                 Http.jsonBody <|
                                     JE.object
                                         [ ( "ipfs_hash", JE.string cid )
                                         , ( "state", JE.string "queued" )
-                                        , ( "filecoin", JE.bool False )
+                                        , ( "filecoin", JE.bool filecoin )
                                         ]
                             , resolver =
                                 Http.stringResolver
@@ -861,19 +869,29 @@ defaultApiProvider =
                             , timeout = Nothing
                             }
         in
-        \{ projectId, file } toMsg ->
+        \{ projectId, filecoin, file } toMsg ->
             addRequest projectId file
-                |> Task.andThen (pinRequest projectId)
+                |> Task.andThen (pinRequest projectId filecoin)
                 |> Task.attempt toMsg
 
     -- Make a request to the pre-configured IPFS RPC via the server.
     -- `id` selects which pre-configured provider on the backend to use.
+    -- `filecoin` asks the server to also pin to Filecoin; only honored when
+    -- the preconfig is Blockfrost and was admin-opted-in to Filecoin.
     , ipfsAddFile =
-        \{ id, file } toMsg ->
+        \{ id, filecoin, file } toMsg ->
             Http.request
                 { method = "POST"
                 , headers = []
-                , url = "/ipfs-pin/file?preconfig_id=" ++ Url.percentEncode id
+                , url =
+                    "/ipfs-pin/file?preconfig_id="
+                        ++ Url.percentEncode id
+                        ++ (if filecoin then
+                                "&filecoin=true"
+
+                            else
+                                ""
+                           )
                 , body = Http.multipartBody [ Http.filePart "file" file ]
                 , expect = Http.expectStringResponse toMsg responseToIpfsAnswer
                 , timeout = Nothing

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -689,7 +689,7 @@ update msg model =
         ( GotPdfAsFile file, { page } ) ->
             case page of
                 PreparationPage pageModel ->
-                    Page.Preparation.pinPdfFile file pageModel
+                    Page.Preparation.pinPdfFile model.ipfsPreconfig file pageModel
                         |> Tuple.mapFirst (\newPageModel -> { model | page = PreparationPage newPageModel })
                         |> Tuple.mapSecond (Cmd.map PreparationPageMsg)
 
@@ -699,7 +699,7 @@ update msg model =
         ( GotRationaleAsFile file, { page } ) ->
             case page of
                 PreparationPage pageModel ->
-                    Page.Preparation.pinRationaleFile file pageModel
+                    Page.Preparation.pinRationaleFile model.ipfsPreconfig file pageModel
                         |> Tuple.mapFirst (\newPageModel -> { model | page = PreparationPage newPageModel })
                         |> Tuple.mapSecond (Cmd.map PreparationPageMsg)
 

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -432,6 +432,7 @@ type alias StorageConfigForm =
     , nmkrUserId : String
     , nmkrApiToken : String
     , blockfrostProjectId : String
+    , blockfrostFilecoin : Bool
     , ipfsServer : String
     , headers : List ( String, String )
     , error : Maybe String
@@ -445,6 +446,7 @@ initStorageConfigForm =
     , nmkrUserId = ""
     , nmkrApiToken = ""
     , blockfrostProjectId = ""
+    , blockfrostFilecoin = False
     , ipfsServer = "https://ipfs-rpc.mycompany.org/api/v0"
     , headers = [ ( "Authorization", "Basic {token}" ) ]
     , error = Nothing
@@ -475,10 +477,11 @@ applyProviderToForm provider form =
         PreconfigIpfs { id } ->
             { form | publishSet = PreconfigKind id :: form.publishSet }
 
-        BlockfrostIpfs { projectId } ->
+        BlockfrostIpfs { projectId, filecoin } ->
             { form
                 | publishSet = BlockfrostKind :: form.publishSet
                 , blockfrostProjectId = projectId
+                , blockfrostFilecoin = filecoin
             }
 
         NmkrIpfs { userId, apiToken } ->
@@ -503,7 +506,7 @@ on the variant itself; they are derived at view time from `ProviderKind`
 -}
 type IpfsProvider
     = PreconfigIpfs { id : String }
-    | BlockfrostIpfs { projectId : String }
+    | BlockfrostIpfs { projectId : String, filecoin : Bool }
     | NmkrIpfs { userId : String, apiToken : String }
     | CustomIpfsProvider { ipfsServer : String, headers : List ( String, String ) }
 
@@ -570,10 +573,11 @@ encodeIpfsProvider provider =
                 , ( "id", JE.string id )
                 ]
 
-        BlockfrostIpfs { projectId } ->
+        BlockfrostIpfs { projectId, filecoin } ->
             JE.object
                 [ ( "type", JE.string "BlockfrostIpfs" )
                 , ( "projectId", JE.string projectId )
+                , ( "filecoin", JE.bool filecoin )
                 ]
 
         NmkrIpfs { userId, apiToken } ->
@@ -664,8 +668,9 @@ ipfsProviderDecoder ipfsPreconfig =
                                 )
 
                     "BlockfrostIpfs" ->
-                        JD.map (\projectId -> BlockfrostIpfs { projectId = projectId })
+                        JD.map2 (\projectId filecoin -> BlockfrostIpfs { projectId = projectId, filecoin = filecoin })
                             (JD.field "projectId" JD.string)
+                            (JD.oneOf [ JD.field "filecoin" JD.bool, JD.succeed False ])
 
                     "NmkrIpfs" ->
                         JD.map2 (\userId apiToken -> NmkrIpfs { userId = userId, apiToken = apiToken })
@@ -823,6 +828,7 @@ type Msg
     | StorageModeSelected StorageMode
     | IpfsProviderToggled ProviderKind
     | BlockfrostProjectIdChange String
+    | BlockfrostFilecoinToggled Bool
     | NmkrUserIdChange String
     | NmkrApiTokenChange String
     | IpfsServerChange String
@@ -882,12 +888,14 @@ type Msg
 {-| The set of pre-configured IPFS providers exposed by the server.
 
 Each entry is identified by a stable `id` (a slug from the backend config).
-Only public metadata (label, description) is included; secrets such as API
-tokens stay on the backend and are looked up by id at upload time.
+Only public metadata (label, description, supportsFilecoin) is included;
+secrets such as API tokens stay on the backend and are looked up by id at
+upload time. `supportsFilecoin` is `True` when the backend admin opted this
+preconfig in to Filecoin pinning for rationale JSON.
 
 -}
 type alias IpfsPreconfig =
-    List { id : String, label : String, description : String }
+    List { id : String, label : String, description : String, supportsFilecoin : Bool }
 
 
 {-| Configuration required by the update function.
@@ -1222,6 +1230,12 @@ innerUpdate ctx msg model =
 
         BlockfrostProjectIdChange projectId ->
             ( updateStorageConfigForm (\form -> { form | blockfrostProjectId = projectId }) model
+            , Cmd.none
+            , Nothing
+            )
+
+        BlockfrostFilecoinToggled filecoin ->
+            ( updateStorageConfigForm (\form -> { form | blockfrostFilecoin = filecoin }) model
             , Cmd.none
             , Nothing
             )
@@ -2450,7 +2464,7 @@ buildIpfsProviders form =
                             Err "Missing blockfrost project id"
 
                         projectId ->
-                            Ok (BlockfrostIpfs { projectId = projectId })
+                            Ok (BlockfrostIpfs { projectId = projectId, filecoin = form.blockfrostFilecoin })
 
                 NmkrKind ->
                     case String.trim form.nmkrUserId of
@@ -2721,8 +2735,8 @@ rationaleFromForm form =
     }
 
 
-pinPdfFile : JD.Value -> Model -> ( Model, Cmd Msg )
-pinPdfFile fileAsValue (Model model) =
+pinPdfFile : IpfsPreconfig -> JD.Value -> Model -> ( Model, Cmd Msg )
+pinPdfFile ipfsPreconfig fileAsValue (Model model) =
     case ( JD.decodeValue File.decoder fileAsValue, model.storageConfigStep, model.rationaleCreationStep ) of
         ( Err error, _, Validating form _ ) ->
             ( Model { model | rationaleCreationStep = Preparing { form | error = Just <| JD.errorToString error } }
@@ -2736,7 +2750,8 @@ pinPdfFile fileAsValue (Model model) =
                         Validating form
                             { validating | uploads = initUploadProgress (List.map providerKind providers) }
                 }
-            , Cmd.batch (List.map (uploadFileCmd file) providers)
+              -- The auto-generated PDF never goes to Filecoin; only the JSON rationale does.
+            , Cmd.batch (List.map (uploadFileCmd ipfsPreconfig { filecoinIsDesired = False } file) providers)
             )
 
         -- Ignore if we aren't validating the rationale storage step
@@ -2744,17 +2759,35 @@ pinPdfFile fileAsValue (Model model) =
             ( Model model, Cmd.none )
 
 
-uploadFileCmd : File -> IpfsProvider -> Cmd Msg
-uploadFileCmd file provider =
+{-| Upload a file to one of the configured IPFS providers.
+
+`filecoinIsDesired` is set by the caller depending on what's being uploaded:
+True for rationale JSON, False for the auto-generated PDF. It's combined with
+the per-provider opt-in (Blockfrost's `filecoin` flag, or the backend
+preconfig's `supportsFilecoin` flag from `IpfsPreconfig`) so Filecoin pinning
+is enabled only when the provider supports it AND the caller asks for it.
+
+-}
+uploadFileCmd : IpfsPreconfig -> { filecoinIsDesired : Bool } -> File -> IpfsProvider -> Cmd Msg
+uploadFileCmd ipfsPreconfig { filecoinIsDesired } file provider =
     case provider of
         PreconfigIpfs { id } ->
+            let
+                preconfigSupportsFilecoin =
+                    lookupPreconfig ipfsPreconfig id
+                        |> Maybe.map .supportsFilecoin
+                        |> Maybe.withDefault False
+            in
             Api.defaultApiProvider.ipfsAddFile
-                { id = id, file = file }
+                { id = id
+                , filecoin = filecoinIsDesired && preconfigSupportsFilecoin
+                , file = file
+                }
                 (GotIpfsAnswer (PreconfigKind id))
 
-        BlockfrostIpfs { projectId } ->
+        BlockfrostIpfs { projectId, filecoin } ->
             Api.defaultApiProvider.ipfsAddFileBlockfrost
-                { projectId = projectId, file = file }
+                { projectId = projectId, filecoin = filecoinIsDesired && filecoin, file = file }
                 (GotIpfsAnswer BlockfrostKind)
 
         NmkrIpfs { userId, apiToken } ->
@@ -3143,8 +3176,8 @@ sendPinRequest ctx form model =
             )
 
 
-pinRationaleFile : JD.Value -> Model -> ( Model, Cmd Msg )
-pinRationaleFile fileAsValue (Model model) =
+pinRationaleFile : IpfsPreconfig -> JD.Value -> Model -> ( Model, Cmd Msg )
+pinRationaleFile ipfsPreconfig fileAsValue (Model model) =
     case ( JD.decodeValue File.decoder fileAsValue, model.storageConfigStep, model.permanentStorageStep ) of
         ( Err error, _, Validating form _ ) ->
             ( Model { model | permanentStorageStep = Preparing { form | error = Just <| JD.errorToString error } }
@@ -3157,7 +3190,8 @@ pinRationaleFile fileAsValue (Model model) =
                     | permanentStorageStep =
                         Validating form (initUploadProgress (List.map providerKind providers))
                 }
-            , Cmd.batch (List.map (uploadFileCmd file) providers)
+              -- Rationale JSON: opt into Filecoin where the provider allows it.
+            , Cmd.batch (List.map (uploadFileCmd ipfsPreconfig { filecoinIsDesired = True } file) providers)
             )
 
         -- Ignore if we aren't validating the rationale storage step
@@ -4614,6 +4648,20 @@ viewBlockfrostForm form =
             , value = form.blockfrostProjectId
             , onInputMsg = BlockfrostProjectIdChange
             }
+        , div [ HA.style "margin-top" "1rem" ]
+            [ Helper.checkbox
+                { id = "blockfrost-filecoin"
+                , label = " Also pin the rationale JSON to Filecoin"
+                }
+                form.blockfrostFilecoin
+                BlockfrostFilecoinToggled
+            , Html.p
+                [ HA.style "opacity" "0.7"
+                , HA.style "font-size" "0.9em"
+                , HA.style "margin-top" "0.25rem"
+                ]
+                [ text "Note: Filecoin pin completion can take up to 72 hours." ]
+            ]
         ]
 
 
@@ -4740,7 +4788,7 @@ viewIpfsProviderInfo ipfsPreconfig provider =
         PreconfigIpfs _ ->
             defaultStorageConfigInfo label description
 
-        BlockfrostIpfs { projectId } ->
+        BlockfrostIpfs { projectId, filecoin } ->
             Helper.storageProviderCard
                 [ Helper.storageProviderHeader label description
                 , Helper.storageConfigItem "Project ID"
@@ -4749,6 +4797,17 @@ viewIpfsProviderInfo ipfsPreconfig provider =
                         , HA.style "word-break" "break-all"
                         ]
                         [ text (String.left 10 projectId ++ "..." ++ String.right 6 projectId) ]
+                    )
+                , Helper.storageConfigItem "Filecoin pinning"
+                    (Html.p []
+                        [ text
+                            (if filecoin then
+                                "Enabled (rationale JSON only)"
+
+                             else
+                                "Disabled"
+                            )
+                        ]
                     )
                 ]
 
@@ -4791,9 +4850,16 @@ providerKindLabel : IpfsPreconfig -> ProviderKind -> String
 providerKindLabel ipfsPreconfig kind =
     case kind of
         PreconfigKind id ->
-            lookupPreconfig ipfsPreconfig id
-                |> Maybe.map .label
-                |> Maybe.withDefault ("Pre-configured IPFS (" ++ id ++ ")")
+            case lookupPreconfig ipfsPreconfig id of
+                Just preconfig ->
+                    if preconfig.supportsFilecoin then
+                        preconfig.label ++ " (with Filecoin)"
+
+                    else
+                        preconfig.label
+
+                Nothing ->
+                    "Pre-configured IPFS (" ++ id ++ ")"
 
         BlockfrostKind ->
             "Blockfrost"
@@ -4809,9 +4875,17 @@ providerKindDescription : IpfsPreconfig -> ProviderKind -> String
 providerKindDescription ipfsPreconfig kind =
     case kind of
         PreconfigKind id ->
-            lookupPreconfig ipfsPreconfig id
-                |> Maybe.map .description
-                |> Maybe.withDefault "Pre-configured IPFS server (no longer available)."
+            case lookupPreconfig ipfsPreconfig id of
+                Just preconfig ->
+                    if preconfig.supportsFilecoin then
+                        preconfig.description
+                            ++ " The rationale JSON is also pinned to Filecoin (completion may take up to 72 hours)."
+
+                    else
+                        preconfig.description
+
+                Nothing ->
+                    "Pre-configured IPFS server (no longer available)."
 
         BlockfrostKind ->
             "Using Blockfrost IPFS server to store your files."
@@ -4823,7 +4897,7 @@ providerKindDescription ipfsPreconfig kind =
             "Using a custom IPFS server configuration to store your files. The RPC should provide the /add?pin=true endpoint with answers equivalent to those described in the official kubo IPFS RPC docs: https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-add"
 
 
-lookupPreconfig : IpfsPreconfig -> String -> Maybe { id : String, label : String, description : String }
+lookupPreconfig : IpfsPreconfig -> String -> Maybe { id : String, label : String, description : String, supportsFilecoin : Bool }
 lookupPreconfig ipfsPreconfig id =
     List.Extra.find (\p -> p.id == id) ipfsPreconfig
 


### PR DESCRIPTION
Fix #164 

With the previous PRs to enable multi-ipfs providers #170 and multi pre-configured providers on the server #174, this is now the final PR to fully support issue #164.

## Summary of this PR

Adds optional Filecoin pinning support for Blockfrost IPFS providers, applied only to rationale JSON uploads (PDFs are never pinned to Filecoin).

**Backend**
- Blockfrost preconfig entries accept an optional `"filecoin": true` field (admin opt-in).
- Public preconfig view now includes `supportsFilecoin: bool` so the frontend can surface which providers pin to Filecoin.
- `/ipfs-pin/file` and `/ipfs-pin/json` accept a `filecoin` flag; honored only when the resolved preconfig is Blockfrost and was admin-opted-in.
- The Blockfrost `pin/add` call now sends both the `?filecoin=true` query param and the documented JSON body (`ipfs_hash` / `state` / `filecoin`).

**Frontend**
- `BlockfrostIpfs` provider variant gains a `filecoin : Bool`; the Blockfrost form has a "Also pin the rationale JSON to Filecoin" checkbox with a note that completion can take up to 72 hours.
- `IpfsPreconfig` entries gain `supportsFilecoin`; preconfigs that opt in show "(with Filecoin)" in their label and the 72-hour note in their description.
- `uploadFileCmd` now takes a `filecoinIsDesired` flag — `True` for rationale JSON (`pinRationaleFile`), `False` for PDFs (`pinPdfFile`) — combined with the provider's own opt-in so Filecoin is only requested when both sides agree.
- Direct Blockfrost client call updated to use the documented body+query-param form.