### PR TITLE
Fix error in the blockfrost ipfs api requests

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -467,19 +467,12 @@ async def pin_to_ipfs_common(
                     detail="Blockfrost IPFS add response missing ipfs_hash",
                 )
 
-            # Blockfrost expects both the query param and the JSON body.
-            # See https://blockfrost.dev/start-building/ipfs/
             pin_url = f"{server_url}/ipfs/pin/add/{cid}"
             if use_filecoin:
                 pin_url += "?filecoin=true"
             pin_response = await app.async_client.post(  # type: ignore
                 url=pin_url,
                 headers=headers,
-                json={
-                    "ipfs_hash": cid,
-                    "state": "queued",
-                    "filecoin": use_filecoin,
-                },
             )
 
             if pin_response.status_code != 200:

--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -839,13 +839,7 @@ defaultApiProvider =
                                         else
                                             ""
                                        )
-                            , body =
-                                Http.jsonBody <|
-                                    JE.object
-                                        [ ( "ipfs_hash", JE.string cid )
-                                        , ( "state", JE.string "queued" )
-                                        , ( "filecoin", JE.bool filecoin )
-                                        ]
+                            , body = Http.emptyBody
                             , resolver =
                                 Http.stringResolver
                                     (\pinResponse ->


### PR DESCRIPTION
Backend now sends POST /ipfs/pin/add/{cid} (with optional ?filecoin=true) and no body. The frontend's direct-Blockfrost path uses Http.emptyBody. The misleading comment about needing a JSON body is gone.