### PR TITLE
Move koios api token to a configurable env var (temporary fix)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -80,7 +80,10 @@ NETWORK_ID=0
 # OG_BASE_URL=https://votes.example.org
 # OG_CARD_CACHE_DIR: where rendered cards are cached (default: system temp dir).
 # OG_CARD_CACHE_DIR=/var/cache/og-cards
-# KOIOS_API_TOKEN: override the token used to resolve proposal titles.
+# KOIOS_API_TOKEN: override the Koios API token. Used both for the server's own
+#   Koios calls (e.g. resolving proposal titles) and threaded to the frontend
+#   via the init flags so it can talk to Koios directly.
+#   WARNING!!! This is publicly viewable in the JS code shipped to browsers.
 # KOIOS_API_TOKEN=...
 
 # Preconfiguration of some voters for fast selection

--- a/backend/README.md
+++ b/backend/README.md
@@ -110,8 +110,11 @@ its own domain with no configuration. All related variables are optional:
   host distinct from the app's own host). Leave unset to auto-derive per request.
 - `OG_CARD_CACHE_DIR`: directory for the rendered card cache (default: a
   `og-cards/` folder under the system temp dir).
-- `KOIOS_API_TOKEN`: override the Koios token used to resolve proposal titles
-  (a public free-tier token is used by default).
+- `KOIOS_API_TOKEN`: override the Koios token (a public free-tier token is used
+  by default). It is used both for the server's own Koios calls (e.g. resolving
+  proposal titles) and threaded to the frontend via the init flags. Note that it
+  is shipped to the browser in the page's JS and is therefore publicly viewable,
+  so only use a token that is safe to expose.
 
 Rendering needs Pillow (a project dependency) and a TrueType font. The Docker
 image bundles one via the `font-dejavu` package; without a usable font the

--- a/backend/server.py
+++ b/backend/server.py
@@ -215,7 +215,10 @@ def _koios_api_url(network_id: Optional[str]) -> str:
     return KOIOS_MAINNET_URL if network_id == "Mainnet" else KOIOS_PREVIEW_URL
 
 
-# Same free-tier token the frontend ships with (already public). Overridable.
+# Free-tier Koios API token. Used both for the server's own Koios calls and
+# threaded to the frontend via the init flags. Overridable via the env var.
+# WARNING: this is shipped to the browser in the page's JS, so it is publicly
+# viewable. Only use a token that is safe to expose (e.g. a free-tier one).
 KOIOS_API_TOKEN = os.getenv(
     "KOIOS_API_TOKEN",
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhZGRyIjoic3Rha2UxdXljY3J5MzZwcXB0aGV4cmw5eW4zZDN6azJrbGR3N3lhdG0wM2gwcHU1eXdjMHFqMzYyNzQiLCJleHAiOjE4MDI5NDcwMTIsInRpZXIiOjEsInByb2pJRCI6Ind5Wk1Sb0ZmYnBKdmNuYncifQ.JMJNKGGXo_yDBottzKUB34D1afR6-2j3vtxw70k1Les",
@@ -362,6 +365,7 @@ def _base_context(request: Request) -> dict:
     return {
         "request": request,
         "network_id": NETWORK_ID,
+        "koios_api_token": KOIOS_API_TOKEN,
         "ipfs_preconfigs": IPFS_PRECONFIGS_PUBLIC_JSON,
         "preconfigured_voters": PRECONFIGURED_VOTERS_JSON,
         "preconfigured_authors": PRECONFIGURED_AUTHORS_JSON,

--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -29,14 +29,6 @@ import Task
 import Url
 
 
-{-| Free Tier Koios API token.
-Expiration date: 2027-02-18.
--}
-koiosApiToken : String
-koiosApiToken =
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhZGRyIjoic3Rha2UxdXljY3J5MzZwcXB0aGV4cmw5eW4zZDN6azJrbGR3N3lhdG0wM2gwcHU1eXdjMHFqMzYyNzQiLCJleHAiOjE4MDI5NDcwMTIsInRpZXIiOjEsInByb2pJRCI6Ind5Wk1Sb0ZmYnBKdmNuYncifQ.JMJNKGGXo_yDBottzKUB34D1afR6-2j3vtxw70k1Les"
-
-
 {-| Overview of all the requests that the app may do.
 
 We could get rid of this type entirely and instead just expose individual functions.
@@ -50,17 +42,17 @@ So this is how there is a mix of regular `(...) -> Cmd msg` and `ConcurrentTask 
 
 -}
 type alias ApiProvider msg =
-    { loadProtocolParams : NetworkId -> (Result Http.Error ProtocolParams -> msg) -> Cmd msg
-    , queryEpoch : NetworkId -> (Result Http.Error Int -> msg) -> Cmd msg
-    , queryConstitution : NetworkId -> (Result Http.Error String -> msg) -> Cmd msg
-    , loadGovProposals : NetworkId -> Int -> (Result Http.Error (List ActiveProposal) -> msg) -> Cmd msg
+    { loadProtocolParams : String -> NetworkId -> (Result Http.Error ProtocolParams -> msg) -> Cmd msg
+    , queryEpoch : String -> NetworkId -> (Result Http.Error Int -> msg) -> Cmd msg
+    , queryConstitution : String -> NetworkId -> (Result Http.Error String -> msg) -> Cmd msg
+    , loadGovProposals : String -> NetworkId -> Int -> (Result Http.Error (List ActiveProposal) -> msg) -> Cmd msg
     , loadProposalMetadata : String -> ConcurrentTask String ProposalMetadata
     , retrieveTx : NetworkId -> Bytes TransactionId -> ConcurrentTask ConcurrentTask.Http.Error (Bytes Transaction)
     , getScriptInfo : NetworkId -> Bytes CredentialHash -> ConcurrentTask ConcurrentTask.Http.Error ScriptInfo
-    , getDrepInfo : NetworkId -> Credential -> (Result Http.Error DrepInfo -> msg) -> Cmd msg
-    , getCcInfo : NetworkId -> Credential -> (Result Http.Error CcInfo -> msg) -> Cmd msg
-    , getPoolLiveStake : NetworkId -> Bytes Pool.Id -> (Result Http.Error PoolInfo -> msg) -> Cmd msg
-    , getVotes : NetworkId -> Gov.Id -> (Result Http.Error (List OnchainVote) -> msg) -> Cmd msg
+    , getDrepInfo : String -> NetworkId -> Credential -> (Result Http.Error DrepInfo -> msg) -> Cmd msg
+    , getCcInfo : String -> NetworkId -> Credential -> (Result Http.Error CcInfo -> msg) -> Cmd msg
+    , getPoolLiveStake : String -> NetworkId -> Bytes Pool.Id -> (Result Http.Error PoolInfo -> msg) -> Cmd msg
+    , getVotes : String -> NetworkId -> Gov.Id -> (Result Http.Error (List OnchainVote) -> msg) -> Cmd msg
     , ipfsAddFileCustom : { rpc : String, headers : List ( String, String ), file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
     , ipfsAddFileNmkr : { userId : String, apiToken : String, file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
     , ipfsAddFileBlockfrost : { projectId : String, filecoin : Bool, file : File } -> (Result String IpfsAnswer -> msg) -> Cmd msg
@@ -576,7 +568,7 @@ defaultApiProvider =
     in
     -- Get protocol parameters via Koios
     { loadProtocolParams =
-        \networkId toMsg ->
+        \koiosApiToken networkId toMsg ->
             Http.request
                 { method = "POST"
                 , url = koiosUrl networkId ++ "/ogmios"
@@ -595,7 +587,7 @@ defaultApiProvider =
 
     -- Query epoch via Koios
     , queryEpoch =
-        \networkId toMsg ->
+        \koiosApiToken networkId toMsg ->
             Http.request
                 { method = "POST"
                 , url = koiosUrl networkId ++ "/ogmios"
@@ -614,7 +606,7 @@ defaultApiProvider =
 
     -- Query constitution URI via Koios
     , queryConstitution =
-        \networkId toMsg ->
+        \koiosApiToken networkId toMsg ->
             Http.request
                 { method = "POST"
                 , url = koiosUrl networkId ++ "/ogmios"
@@ -633,7 +625,7 @@ defaultApiProvider =
 
     -- Get governance proposals via Koios
     , loadGovProposals =
-        \networkId currentEpoch toMsg ->
+        \koiosApiToken networkId currentEpoch toMsg ->
             let
                 selected_rows =
                     [ "proposal_tx_hash"
@@ -669,7 +661,7 @@ defaultApiProvider =
 
     -- Retrieve DRep info via Koios using an Ogmios endpoint
     , getDrepInfo =
-        \networkId cred toMsg ->
+        \koiosApiToken networkId cred toMsg ->
             Http.request
                 { method = "POST"
                 , url = koiosUrl networkId ++ "/ogmios"
@@ -696,7 +688,7 @@ defaultApiProvider =
 
     -- Retrieve CC member info
     , getCcInfo =
-        \networkId cred toMsg ->
+        \koiosApiToken networkId cred toMsg ->
             Http.request
                 { method = "POST"
                 , url = koiosUrl networkId ++ "/ogmios"
@@ -715,7 +707,7 @@ defaultApiProvider =
 
     -- Retrieve Pool live stake
     , getPoolLiveStake =
-        \networkId poolId toMsg ->
+        \koiosApiToken networkId poolId toMsg ->
             let
                 poolIdBech32 =
                     Pool.toBech32 poolId
@@ -732,7 +724,7 @@ defaultApiProvider =
 
     -- Load past votes for a given voter
     , getVotes =
-        \networkId govId toMsg ->
+        \koiosApiToken networkId govId toMsg ->
             let
                 selected_rows =
                     [ "voter_id"

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -94,6 +94,7 @@ type alias Flags =
     , jsonLdContexts : JsonLdContexts
     , db : Value
     , networkId : Int
+    , koiosApiToken : String
     , ipfsPreconfig : IpfsPreconfig
     , voterPreconfig : List PreconfVoter
     , authorPreconfig : List PreconfAuthor
@@ -199,6 +200,7 @@ type alias Model =
     , taskPool : ConcurrentTask.Pool Msg
     , db : Value
     , networkId : NetworkId
+    , koiosApiToken : String
     , ipfsPreconfig : IpfsPreconfig
     , voterPreconfig : List PreconfVoter
     , authorPreconfig : List PreconfAuthor
@@ -230,13 +232,13 @@ type TaskCompleted
 
 
 init : Flags -> ( Model, Cmd Msg )
-init { url, jsonLdContexts, db, networkId, ipfsPreconfig, voterPreconfig, authorPreconfig } =
+init { url, jsonLdContexts, db, networkId, koiosApiToken, ipfsPreconfig, voterPreconfig, authorPreconfig } =
     let
         networkIdTyped =
             Address.networkIdFromInt networkId |> Maybe.withDefault Testnet
 
         config =
-            ModelConfig jsonLdContexts db networkIdTyped ipfsPreconfig voterPreconfig authorPreconfig
+            ModelConfig jsonLdContexts db networkIdTyped koiosApiToken ipfsPreconfig voterPreconfig authorPreconfig
     in
     initHelper (locationHrefToRoute url) config
 
@@ -271,8 +273,8 @@ initHelper route config =
     ( { model | taskPool = updatedTaskPool }
     , Cmd.batch
         [ cmd
-        , Api.defaultApiProvider.loadProtocolParams model.networkId GotProtocolParams
-        , Api.defaultApiProvider.queryConstitution model.networkId GotConstitution
+        , Api.defaultApiProvider.loadProtocolParams model.koiosApiToken model.networkId GotProtocolParams
+        , Api.defaultApiProvider.queryConstitution model.koiosApiToken model.networkId GotConstitution
         , tasksCmds
         ]
     )
@@ -282,6 +284,7 @@ type alias ModelConfig =
     { jsonLdContexts : JsonLdContexts
     , db : Value
     , networkId : NetworkId
+    , koiosApiToken : String
     , ipfsPreconfig : IpfsPreconfig
     , voterPreconfig : List PreconfVoter
     , authorPreconfig : List PreconfAuthor
@@ -289,7 +292,7 @@ type alias ModelConfig =
 
 
 initialModel : ModelConfig -> Model
-initialModel { jsonLdContexts, db, networkId, ipfsPreconfig, voterPreconfig, authorPreconfig } =
+initialModel { jsonLdContexts, db, networkId, koiosApiToken, ipfsPreconfig, voterPreconfig, authorPreconfig } =
     { page = LandingPage
     , appUrl = routeToAppUrl RouteLanding
     , mobileMenuIsOpen = False
@@ -315,6 +318,7 @@ initialModel { jsonLdContexts, db, networkId, ipfsPreconfig, voterPreconfig, aut
     , taskPool = ConcurrentTask.pool
     , db = db
     , networkId = networkId
+    , koiosApiToken = koiosApiToken
     , ipfsPreconfig = ipfsPreconfig
     , voterPreconfig = voterPreconfig
     , authorPreconfig = authorPreconfig
@@ -673,6 +677,7 @@ update msg model =
                             , costModels = Maybe.map .costModels model.protocolParams
                             , constitutionUri = model.constitutionUri
                             , networkId = model.networkId
+                            , koiosApiToken = model.koiosApiToken
                             , authorPreconfig = model.authorPreconfig
                             , ipfsPreconfig = model.ipfsPreconfig
                             }
@@ -865,7 +870,7 @@ update msg model =
 
                 Ok epoch ->
                     ( { model | epoch = RemoteData.Success epoch }
-                    , Api.defaultApiProvider.loadGovProposals model.networkId epoch GotProposals
+                    , Api.defaultApiProvider.loadGovProposals model.koiosApiToken model.networkId epoch GotProposals
                     )
 
         ( GotProposals result, _ ) ->
@@ -1056,6 +1061,7 @@ handleUrlChange route model =
                     { jsonLdContexts = model.jsonLdContexts
                     , db = model.db
                     , networkId = networkId
+                    , koiosApiToken = model.koiosApiToken
                     , ipfsPreconfig = model.ipfsPreconfig
                     , voterPreconfig = model.voterPreconfig
                     , authorPreconfig = model.authorPreconfig
@@ -1074,7 +1080,7 @@ handleUrlChange route model =
                   }
                 , Cmd.batch
                     [ pushUrlCmd
-                    , Api.defaultApiProvider.queryEpoch model.networkId GotEpoch
+                    , Api.defaultApiProvider.queryEpoch model.koiosApiToken model.networkId GotEpoch
                     , taskCmds
                     ]
                 )
@@ -1085,6 +1091,7 @@ handleUrlChange route model =
                     { jsonLdContexts = model.jsonLdContexts
                     , db = model.db
                     , networkId = networkId
+                    , koiosApiToken = model.koiosApiToken
                     , ipfsPreconfig = model.ipfsPreconfig
                     , voterPreconfig = model.voterPreconfig
                     , authorPreconfig = model.authorPreconfig
@@ -1105,6 +1112,7 @@ handleUrlChange route model =
                     { jsonLdContexts = model.jsonLdContexts
                     , db = model.db
                     , networkId = networkId
+                    , koiosApiToken = model.koiosApiToken
                     , ipfsPreconfig = model.ipfsPreconfig
                     , voterPreconfig = model.voterPreconfig
                     , authorPreconfig = model.authorPreconfig

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -921,6 +921,7 @@ type alias UpdateContext msg =
     , costModels : Maybe CostModels
     , constitutionUri : Maybe String
     , networkId : NetworkId
+    , koiosApiToken : String
     , authorPreconfig : List PreconfAuthor
     , ipfsPreconfig : IpfsPreconfig
     }
@@ -2016,7 +2017,7 @@ checkGovId ctx str =
                         ( ccInfo, fetchCcInfo ) =
                             case Dict.get (Bytes.toHex keyHash) ctx.ccsInfo of
                                 Nothing ->
-                                    ( RemoteData.Loading, Api.defaultApiProvider.getCcInfo ctx.networkId cred GotCcInfo )
+                                    ( RemoteData.Loading, Api.defaultApiProvider.getCcInfo ctx.koiosApiToken ctx.networkId cred GotCcInfo )
 
                                 Just info ->
                                     ( RemoteData.Success info, Cmd.none )
@@ -2028,7 +2029,7 @@ checkGovId ctx str =
                         ( drepInfo, fetchDrepInfo ) =
                             case Dict.get (Bytes.toHex keyHash) ctx.drepsInfo of
                                 Nothing ->
-                                    ( RemoteData.Loading, Api.defaultApiProvider.getDrepInfo ctx.networkId cred GotDrepInfo )
+                                    ( RemoteData.Loading, Api.defaultApiProvider.getDrepInfo ctx.koiosApiToken ctx.networkId cred GotDrepInfo )
 
                                 Just info ->
                                     ( RemoteData.Success info, Cmd.none )
@@ -2040,7 +2041,7 @@ checkGovId ctx str =
                         ( poolInfo, fetchPoolInfo ) =
                             case Dict.get (Bytes.toHex poolId) ctx.poolsInfo of
                                 Nothing ->
-                                    ( RemoteData.Loading, Api.defaultApiProvider.getPoolLiveStake ctx.networkId poolId GotPoolInfo )
+                                    ( RemoteData.Loading, Api.defaultApiProvider.getPoolLiveStake ctx.koiosApiToken ctx.networkId poolId GotPoolInfo )
 
                                 Just info ->
                                     ( RemoteData.Success info, Cmd.none )
@@ -2083,7 +2084,7 @@ checkGovId ctx str =
                         ( ccInfo, fetchCcInfo ) =
                             case Dict.get (Bytes.toHex scriptHash) ctx.ccsInfo of
                                 Nothing ->
-                                    ( RemoteData.Loading, Api.defaultApiProvider.getCcInfo ctx.networkId cred GotCcInfo )
+                                    ( RemoteData.Loading, Api.defaultApiProvider.getCcInfo ctx.koiosApiToken ctx.networkId cred GotCcInfo )
 
                                 Just info ->
                                     ( RemoteData.Success info, Cmd.none )
@@ -2132,7 +2133,7 @@ checkGovId ctx str =
                         ( drepInfo, fetchDrepInfo ) =
                             case Dict.get (Bytes.toHex scriptHash) ctx.drepsInfo of
                                 Nothing ->
-                                    ( RemoteData.Loading, Api.defaultApiProvider.getDrepInfo ctx.networkId cred GotDrepInfo )
+                                    ( RemoteData.Loading, Api.defaultApiProvider.getDrepInfo ctx.koiosApiToken ctx.networkId cred GotDrepInfo )
 
                                 Just info ->
                                     ( RemoteData.Success info, Cmd.none )
@@ -2186,19 +2187,19 @@ confirmVoter ctx form loadedRefUtxos =
 
         Just ((PoolId poolId) as govId) ->
             ( Done form <| Witness.WithPoolCred poolId
-            , Cmd.map ctx.wrapMsg <| Api.defaultApiProvider.getVotes ctx.networkId govId GotVotes
+            , Cmd.map ctx.wrapMsg <| Api.defaultApiProvider.getVotes ctx.koiosApiToken ctx.networkId govId GotVotes
             , Nothing
             )
 
         Just ((DrepId (VKeyHash keyHash)) as govId) ->
             ( Done form <| Witness.WithDrepCred (Witness.WithKey keyHash)
-            , Cmd.map ctx.wrapMsg <| Api.defaultApiProvider.getVotes ctx.networkId govId GotVotes
+            , Cmd.map ctx.wrapMsg <| Api.defaultApiProvider.getVotes ctx.koiosApiToken ctx.networkId govId GotVotes
             , Nothing
             )
 
         Just ((CcHotCredId (VKeyHash keyHash)) as govId) ->
             ( Done form <| Witness.WithCommitteeHotCred (Witness.WithKey keyHash)
-            , Cmd.map ctx.wrapMsg <| Api.defaultApiProvider.getVotes ctx.networkId govId GotVotes
+            , Cmd.map ctx.wrapMsg <| Api.defaultApiProvider.getVotes ctx.koiosApiToken ctx.networkId govId GotVotes
             , Nothing
             )
 
@@ -2254,7 +2255,7 @@ validateScriptVoter ctx form loadedRefUtxos toVoter scriptInfo govId =
                                 }
                         in
                         ( Done { form | error = Nothing } <| toVoter <| Witness.WithScript scriptInfo.scriptHash <| Witness.Native witness
-                        , Cmd.map ctx.wrapMsg <| Api.defaultApiProvider.getVotes ctx.networkId govId GotVotes
+                        , Cmd.map ctx.wrapMsg <| Api.defaultApiProvider.getVotes ctx.koiosApiToken ctx.networkId govId GotVotes
                         , Nothing
                         )
 
@@ -2271,7 +2272,7 @@ validateScriptVoter ctx form loadedRefUtxos toVoter scriptInfo govId =
                             }
                     in
                     ( Done { form | error = Nothing } <| toVoter <| Witness.WithScript scriptInfo.scriptHash <| Witness.Plutus witness
-                    , Cmd.map ctx.wrapMsg <| Api.defaultApiProvider.getVotes ctx.networkId govId GotVotes
+                    , Cmd.map ctx.wrapMsg <| Api.defaultApiProvider.getVotes ctx.koiosApiToken ctx.networkId govId GotVotes
                     , Nothing
                     )
 
@@ -2293,13 +2294,13 @@ validateScriptVoter ctx form loadedRefUtxos toVoter scriptInfo govId =
                     in
                     if Dict.Any.member outputRef loadedRefUtxos then
                         ( Done { form | error = Nothing } voter
-                        , Cmd.map ctx.wrapMsg <| Api.defaultApiProvider.getVotes ctx.networkId govId GotVotes
+                        , Cmd.map ctx.wrapMsg <| Api.defaultApiProvider.getVotes ctx.koiosApiToken ctx.networkId govId GotVotes
                         , Nothing
                         )
 
                     else
                         ( Validating form voter
-                        , Cmd.map ctx.wrapMsg <| Api.defaultApiProvider.getVotes ctx.networkId govId GotVotes
+                        , Cmd.map ctx.wrapMsg <| Api.defaultApiProvider.getVotes ctx.koiosApiToken ctx.networkId govId GotVotes
                         , Api.defaultApiProvider.retrieveTx ctx.networkId outputRef.transactionId
                             |> Storage.cacheWrap
                                 { db = ctx.db, storeName = "tx" }

--- a/frontend/static/index.html
+++ b/frontend/static/index.html
@@ -68,6 +68,7 @@
                 jsonLdContexts,
                 db,
                 networkId: {{network_id}}, // 0: Preview, 1: Mainnet
+                koiosApiToken: {{koios_api_token|tojson}},
                 ipfsPreconfig: JSON.parse({{ipfs_preconfigs|tojson}}),
                 voterPreconfig: JSON.parse({{preconfigured_voters|tojson}}),
                 authorPreconfig: JSON.parse({{preconfigured_authors|tojson}}),


### PR DESCRIPTION
Beware that the koios token is still public. It’s just not fixed in code anymore. It’s a temporary solution. Better fix coming later.