### PR TITLE
Fix the delaying badge display bug

### DIFF
--- a/frontend/src/Helper.elm
+++ b/frontend/src/Helper.elm
@@ -1354,8 +1354,8 @@ showMoreButton hasMore visibleCount totalCount clickMsg =
 
 {-| Card for an individual proposal
 -}
-proposalCard : { title : String, hashIsValid : Bool, pastVote : Maybe Gov.Vote, isRatifying : Bool, isLastEpoch : Bool, expiryText : String, abstract : String, actionType : String, linkUrl : String, linkHex : String, index : Int, relInfo : Maybe { number : Int, follows : Maybe Int, competingWith : List Int, isDelaying : Bool } } -> msg -> Html msg -> Html msg
-proposalCard { title, hashIsValid, pastVote, isRatifying, isLastEpoch, expiryText, abstract, actionType, linkUrl, linkHex, index, relInfo } selectMsg actionIcon =
+proposalCard : { title : String, hashIsValid : Bool, pastVote : Maybe Gov.Vote, isRatifying : Bool, isLastEpoch : Bool, expiryText : String, abstract : String, actionType : String, linkUrl : String, linkHex : String, index : Int, isDelaying : Bool, relInfo : Maybe { number : Int, follows : Maybe Int, competingWith : List Int } } -> msg -> Html msg -> Html msg
+proposalCard { title, hashIsValid, pastVote, isRatifying, isLastEpoch, expiryText, abstract, actionType, linkUrl, linkHex, index, isDelaying, relInfo } selectMsg actionIcon =
     div
         [ HA.style "border" "1px solid #E2E8F0"
         , HA.style "border-radius" "0.75rem"
@@ -1427,7 +1427,7 @@ proposalCard { title, hashIsValid, pastVote, isRatifying, isLastEpoch, expiryTex
 
                 badges : List (Html msg)
                 badges =
-                    viewRelBadges relInfo
+                    viewRelBadges isDelaying relInfo
                         ++ (if hashIsValid then
                                 []
 
@@ -1665,55 +1665,65 @@ viewPastVoteBadge vote =
 
 {-| Render relationship badges (number, follows, competing, delaying) for a proposal.
 Reusable across proposal cards, cart rows, etc.
+
+The "Delaying" badge is intrinsic to the action type (see CIP-1694) and is shown
+whenever `isDelaying` is True, independently of whether the proposal has any
+relationship with other proposals. The other badges (number, follows, competing)
+only appear when relationship info is present.
+
 -}
-viewRelBadges : Maybe { number : Int, follows : Maybe Int, competingWith : List Int, isDelaying : Bool } -> List (Html msg)
-viewRelBadges relInfo =
-    case relInfo of
-        Nothing ->
-            []
+viewRelBadges : Bool -> Maybe { number : Int, follows : Maybe Int, competingWith : List Int } -> List (Html msg)
+viewRelBadges isDelaying relInfo =
+    let
+        smallBadge bgColor color tooltip label =
+            Html.span
+                [ HA.style "display" "inline-flex"
+                , HA.style "align-items" "center"
+                , HA.style "background-color" bgColor
+                , HA.style "color" color
+                , HA.style "font-weight" "600"
+                , HA.style "padding" "0.125rem 0.4rem"
+                , HA.style "border-radius" "0.375rem"
+                , HA.style "font-size" "0.75rem"
+                , HA.style "cursor" "help"
+                , HA.title tooltip
+                ]
+                [ text label ]
 
-        Just info ->
-            let
-                smallBadge bgColor color tooltip label =
-                    Html.span
-                        [ HA.style "display" "inline-flex"
-                        , HA.style "align-items" "center"
-                        , HA.style "background-color" bgColor
-                        , HA.style "color" color
-                        , HA.style "font-weight" "600"
-                        , HA.style "padding" "0.125rem 0.4rem"
-                        , HA.style "border-radius" "0.375rem"
-                        , HA.style "font-size" "0.75rem"
-                        , HA.style "cursor" "help"
-                        , HA.title tooltip
-                        ]
-                        [ text label ]
-            in
-            smallBadge "#E2E8F0" "#4A5568" "Proposal number for cross-referencing related proposals" ("#" ++ String.fromInt info.number)
-                :: (case info.follows of
-                        Just n ->
-                            [ smallBadge "#FEF3C7" "#D97706" ("This proposal depends on #" ++ String.fromInt n ++ " being enacted first") ("Follows #" ++ String.fromInt n) ]
+        relationshipBadges =
+            case relInfo of
+                Nothing ->
+                    []
 
-                        Nothing ->
-                            []
-                   )
-                ++ (if List.isEmpty info.competingWith then
-                        []
+                Just info ->
+                    smallBadge "#E2E8F0" "#4A5568" "Proposal number for cross-referencing related proposals" ("#" ++ String.fromInt info.number)
+                        :: (case info.follows of
+                                Just n ->
+                                    [ smallBadge "#FEF3C7" "#D97706" ("This proposal depends on #" ++ String.fromInt n ++ " being enacted first") ("Follows #" ++ String.fromInt n) ]
 
-                    else
-                        [ smallBadge "#FEE2E2" "#DC2626" "These proposals share the same purpose and parent action, so only one can be enacted" ("Competing #" ++ String.join ", #" (List.map String.fromInt info.competingWith)) ]
-                   )
-                ++ (if info.isDelaying then
-                        [ smallBadge "#EDE9FE" "#7C3AED" "If ratified, this action delays all other ratifications for the rest of the epoch" "Delaying" ]
+                                Nothing ->
+                                    []
+                           )
+                        ++ (if List.isEmpty info.competingWith then
+                                []
 
-                    else
-                        []
-                   )
+                            else
+                                [ smallBadge "#FEE2E2" "#DC2626" "These proposals share the same purpose and parent action, so only one can be enacted" ("Competing #" ++ String.join ", #" (List.map String.fromInt info.competingWith)) ]
+                           )
+
+        delayingBadges =
+            if isDelaying then
+                [ smallBadge "#EDE9FE" "#7C3AED" "If ratified, this action delays all other ratifications for the rest of the epoch" "Delaying" ]
+
+            else
+                []
+    in
+    relationshipBadges ++ delayingBadges
 
 
 {-| List of proposals already in the cart for the currently selected voter.
 -}
-viewProposalsListInCart : List { proposalTitle : String, voteIntent : VoteIntent, relInfo : Maybe { number : Int, follows : Maybe Int, competingWith : List Int, isDelaying : Bool } } -> Html msg
+viewProposalsListInCart : List { proposalTitle : String, voteIntent : VoteIntent, isDelaying : Bool, relInfo : Maybe { number : Int, follows : Maybe Int, competingWith : List Int } } -> Html msg
 viewProposalsListInCart items =
     if List.isEmpty items then
         text ""
@@ -1733,8 +1743,8 @@ viewProposalsListInCart items =
             ]
 
 
-viewProposalRowAt : Int -> { proposalTitle : String, voteIntent : VoteIntent, relInfo : Maybe { number : Int, follows : Maybe Int, competingWith : List Int, isDelaying : Bool } } -> Html msg
-viewProposalRowAt index { proposalTitle, voteIntent, relInfo } =
+viewProposalRowAt : Int -> { proposalTitle : String, voteIntent : VoteIntent, isDelaying : Bool, relInfo : Maybe { number : Int, follows : Maybe Int, competingWith : List Int } } -> Html msg
+viewProposalRowAt index { proposalTitle, voteIntent, isDelaying, relInfo } =
     Html.li
         [ HA.style "display" "flex"
         , HA.style "justify-content" "space-between"
@@ -1762,7 +1772,7 @@ viewProposalRowAt index { proposalTitle, voteIntent, relInfo } =
                 , HA.style "word-break" "break-word"
                 ]
                 (text proposalTitle
-                    :: (case viewRelBadges relInfo of
+                    :: (case viewRelBadges isDelaying relInfo of
                             [] ->
                                 []
 

--- a/frontend/src/Page/Preparation.elm
+++ b/frontend/src/Page/Preparation.elm
@@ -64,7 +64,7 @@ import Page.Cart as Cart
 import Platform.Cmd as Cmd
 import Process
 import ProposalMetadata exposing (AuthorWitness, ProposalMetadata)
-import ProposalRelationships exposing (ProposalRelInfo)
+import ProposalRelationships exposing (ProposalRelInfo, isDelayingActionType)
 import RemoteData exposing (RemoteData, WebData)
 import ScriptInfo exposing (ScriptInfo)
 import Set exposing (Set)
@@ -4117,9 +4117,13 @@ viewProposalList ctx form maybeVoter proposalsDict visibleCount =
                                 (\( actionIdStr, { proposalTitle, voteIntent } ) ->
                                     { proposalTitle = proposalTitle
                                     , voteIntent = voteIntent
+                                    , isDelaying =
+                                        Dict.get actionIdStr proposalsDict
+                                            |> Maybe.map (\p -> isDelayingActionType p.actionType)
+                                            |> Maybe.withDefault False
                                     , relInfo =
                                         Dict.get actionIdStr ctx.proposalRelationships
-                                            |> Maybe.map (\info -> { number = info.number, follows = info.follows, competingWith = info.competingWith, isDelaying = info.isDelaying })
+                                            |> Maybe.map (\info -> { number = info.number, follows = info.follows, competingWith = info.competingWith })
                                     }
                                 )
         in
@@ -4185,10 +4189,11 @@ viewProposalCardHelper wrapMsg networkId currentEpoch getPastVote relationships 
 
         relInfo =
             Dict.get idString relationships
-                |> Maybe.map (\info -> { number = info.number, follows = info.follows, competingWith = info.competingWith, isDelaying = info.isDelaying })
+                |> Maybe.map (\info -> { number = info.number, follows = info.follows, competingWith = info.competingWith })
     in
     Helper.proposalCard
         { hashIsValid = hashIsValid
+        , isDelaying = isDelayingActionType proposal.actionType
         , pastVote = pastVote
         , isRatifying = proposal.ratified == currentEpoch
         , isLastEpoch = currentEpoch == Just (proposal.epoch_validity.end - 1)

--- a/frontend/src/ProposalRelationships.elm
+++ b/frontend/src/ProposalRelationships.elm
@@ -1,6 +1,6 @@
 module ProposalRelationships exposing
     ( GovernancePurpose(..), ProposalRelInfo
-    , actionLatestEnacted, isChainableAction, proposalRelationships
+    , actionLatestEnacted, isChainableAction, isDelayingActionType, proposalRelationships
     )
 
 {-| Module for computing governance proposal relationships.
@@ -11,7 +11,7 @@ enacted, the rest expire. This module provides the types and logic to
 detect and represent these relationships.
 
 @docs GovernancePurpose, ProposalRelInfo
-@docs actionLatestEnacted, isChainableAction, proposalRelationships
+@docs actionLatestEnacted, isChainableAction, isDelayingActionType, proposalRelationships
 
 -}
 
@@ -40,7 +40,6 @@ type alias ProposalRelInfo =
     , latestEnacted : Maybe ActionId
     , follows : Maybe Int
     , competingWith : List Int
-    , isDelaying : Bool
     }
 
 
@@ -63,6 +62,36 @@ isChainableAction actionType =
             True
 
         "NewConstitution" ->
+            True
+
+        _ ->
+            False
+
+
+{-| Whether a governance action, if ratified, delays the ratification of all
+other governance actions until the first epoch after its enactment.
+
+Per CIP-1694, the delaying actions are: motion of no-confidence, update
+committee, new constitution, and hard-fork initiation. Protocol parameter
+changes, treasury withdrawals and info actions are not delaying.
+
+This property is intrinsic to the action type: it holds regardless of whether
+the proposal competes with or depends on any other proposal.
+
+-}
+isDelayingActionType : String -> Bool
+isDelayingActionType actionType =
+    case actionType of
+        "NoConfidence" ->
+            True
+
+        "NewCommittee" ->
+            True
+
+        "NewConstitution" ->
+            True
+
+        "HardForkInitiation" ->
             True
 
         _ ->
@@ -244,15 +273,6 @@ proposalRelationships chainableProposals =
                         |> Maybe.withDefault []
                         |> List.filterMap (\siblingId -> Dict.get siblingId bech32ToNumber)
                         |> List.sort
-
-                isDelaying =
-                    case proposal.actionType of
-                        "ParameterChange" ->
-                            False
-
-                        _ ->
-                            -- All other chainable types are delaying
-                            True
             in
             ( bech32Id
             , { number = index + 1
@@ -260,7 +280,6 @@ proposalRelationships chainableProposals =
               , latestEnacted = latestEnacted
               , follows = follows
               , competingWith = competingWith
-              , isDelaying = isDelaying
               }
             )
     in


### PR DESCRIPTION
The "delaying" tag was only display when there were other competing gov actions in relationship with it. This was a bug. A delaying gov action will delay others ratification irrespective of the type of other gov actions at the same epoch.