### PR TITLE
Migrate Matomo defaults to self-hosted instance

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -52,9 +52,9 @@ IPFS_PRECONFIGS_JSON="[
 # ]"
 
 # Matomo Analytics
-MATOMO_URL="https://cardanofoundation.matomo.cloud/"
-MATOMO_SITE_ID="13"
-MATOMO_JS_URL="https://cdn.matomo.cloud/cardanofoundation.matomo.cloud/matomo.js" # URL for the Matomo JavaScript file
+MATOMO_URL="https://analytics.cf-app.org/"
+MATOMO_SITE_ID="5"
+MATOMO_JS_URL="https://analytics.cf-app.org/matomo.js" # URL for the Matomo JavaScript file
 MATOMO_SCRIPT='
       var _paq = window._paq = window._paq || [];
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */

--- a/backend/README.md
+++ b/backend/README.md
@@ -37,9 +37,9 @@ IPFS_PRECONFIGS_JSON="[
 NETWORK_ID=0
 
 # Matomo Analytics (optional - can be removed for self-hosted deployments)
-MATOMO_URL="https://cardanofoundation.matomo.cloud/"
-MATOMO_SITE_ID="13"
-MATOMO_JS_URL="https://cdn.matomo.cloud/cardanofoundation.matomo.cloud/matomo.js"
+MATOMO_URL="https://analytics.cf-app.org/"
+MATOMO_SITE_ID="5"
+MATOMO_JS_URL="https://analytics.cf-app.org/matomo.js"
 MATOMO_SCRIPT='
       var _paq = window._paq = window._paq || [];
       _paq.push(["trackPageView"]);


### PR DESCRIPTION
## Summary

We are moving off the Matomo Cloud plan (`cardanofoundation.matomo.cloud`) to a self-hosted Matomo at `analytics.cf-app.org`.

The Matomo integration here is fully env-driven, so no code changes — this updates the documented defaults:

- `backend/.env.example` and `backend/README.md`: `MATOMO_URL` → `https://analytics.cf-app.org/`, `MATOMO_SITE_ID` → `5`, `MATOMO_JS_URL` → `https://analytics.cf-app.org/matomo.js`

## Deployment note

The deployed backend's actual environment variables must be updated to the same values — this PR only changes the examples/docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)