### PR TITLE
Add DRepTalk to the governance ecosystem list

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -2108,6 +2108,10 @@ governanceTools =
       , url = "https://www.drep.fun/"
       , description = "Minimalist tool for DReps to vote on proposals."
       }
+    , { name = "DRepTalk"
+      , url = "https://dreptalk.com"
+      , description = "A public discussion forum for Cardano governance, where every on-chain action has its own thread and DReps, SPOs, and CC members post authenticated by wallet signature."
+      }
     , { name = "governancespace.com"
       , url = "https://governancespace.com"
       , description = "Another alternative comprehensive platform for Cardano governance, still WIP."


### PR DESCRIPTION
Adds DRepTalk as an entry in the "Cardano Governance Ecosystem" list on the landing page.

DRepTalk is a public discussion forum for Cardano governance: every on-chain governance action has its own discussion thread, and DReps, SPOs, and CC members post authenticated by wallet signature.

Placed alongside the other recently added tools, matching how new entries have been inserted before.